### PR TITLE
Refactor --project validation, auto-dismiss error popups, fix session…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,28 +201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,53 +244,6 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -668,22 +599,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "containerd-client"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cc6911381d95039f381080ec148024d2bb0044a03363542b0a6b0b2c46592"
-dependencies = [
- "hyper-util",
- "prost",
- "prost-build",
- "prost-types",
- "tokio",
- "tonic",
- "tonic-build",
- "tower 0.5.3",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1220,12 +1135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,25 +1375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,12 +1384,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1655,12 +1539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,30 +1557,15 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1738,7 +1601,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1898,16 +1761,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -2021,15 +1874,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2266,12 +2110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,12 +2120,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2322,19 +2154,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "nanosandbox"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "containerd-client",
  "dirs",
  "docker_credential",
  "env_logger",
@@ -2343,7 +2168,6 @@ dependencies = [
  "libloading",
  "log",
  "oci-distribution",
- "prost-types",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2352,7 +2176,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
- "tonic",
  "tracing",
  "unicode-width 0.2.0",
  "uuid",
@@ -2828,36 +2651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap 2.13.0",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,58 +2919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
-dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.117",
- "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,7 +3028,7 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools 0.13.0",
+ "itertools",
  "lru",
  "paste",
  "strum",
@@ -3383,7 +3124,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -3734,7 +3475,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -3878,16 +3619,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -4238,7 +3969,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4261,17 +3992,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -4315,7 +4035,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4328,70 +4048,6 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "prost-types",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "tower"
@@ -4421,7 +4077,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -4555,7 +4211,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools 0.13.0",
+ "itertools",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -4804,7 +4460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4830,7 +4486,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
  "semver",
 ]
 
@@ -4981,15 +4637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5194,7 +4841,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5225,7 +4872,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -5244,7 +4891,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -325,6 +325,9 @@ pub struct AgentPanel {
     pub original_config: Option<nanosandbox::SandboxConfig>,
     /// Whether this panel was resumed from a previous session (agent uses resume command).
     pub is_resumed: bool,
+    /// Whether the user sent at least one keystroke to this agent's terminal.
+    /// Used to decide whether resume flags (--continue) are appropriate on next session load.
+    pub had_interaction: bool,
     /// Overlay notification shown on top of the terminal (message, is_error, remaining ticks).
     /// Replaces previous notification; auto-dismissed after countdown reaches 0.
     pub notification: Option<(String, bool, u8)>,
@@ -368,6 +371,7 @@ impl AgentPanel {
             headless_state: None,
             original_config: None,
             is_resumed: false,
+            had_interaction: false,
             notification: None,
         }
     }
@@ -421,6 +425,8 @@ pub struct App {
     pub settings: nanosandbox::settings::UserSettings,
     /// Temporary status message shown on the status bar (message, remaining ticks).
     pub status_message: Option<(String, u8)>,
+    /// Auto-dismiss countdown for system message popup (remaining ticks, None = manual dismiss).
+    pub system_message_ticks: Option<u8>,
     /// Active colour theme (resolved at startup, switchable via `/theme`).
     pub theme: &'static super::theme::Theme,
     /// Name of the active theme (for display and persistence).
@@ -476,6 +482,7 @@ impl App {
             sidebar_tick_counter: 0,
             settings,
             status_message: None,
+            system_message_ticks: None,
             theme,
             theme_name,
             mouse_selection: None,
@@ -496,6 +503,15 @@ impl App {
     pub fn set_system_message(&mut self, msg: ChatMessage) {
         self.system_messages.clear();
         self.system_messages.push(msg);
+        self.system_message_ticks = None; // manual dismiss only
+    }
+
+    /// Show a system message popup that auto-dismisses after the given number of
+    /// ticks (each tick ≈ 250 ms). ESC still dismisses immediately.
+    pub fn set_system_message_timed(&mut self, msg: ChatMessage, ticks: u8) {
+        self.system_messages.clear();
+        self.system_messages.push(msg);
+        self.system_message_ticks = Some(ticks);
     }
 
     /// Refresh the cached modified files list from the focused panel's project mount.

--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -279,7 +279,32 @@ fn parse_add(parts: &[&str]) -> ParseResult {
             }
             "--project" => {
                 match parts.get(i + 1) {
-                    Some(v) => { project = Some(v.to_string()); i += 2; }
+                    Some(v) => {
+                        let raw = std::path::Path::new(v);
+                        let resolved = if raw.is_absolute() {
+                            raw.to_path_buf()
+                        } else {
+                            std::env::current_dir()
+                                .unwrap_or_default()
+                                .join(raw)
+                        };
+                        if !resolved.exists() {
+                            return ParseResult::Err(format!(
+                                "Project path does not exist: {}\n\
+                                 Usage: /add <agent> --project <path>",
+                                resolved.display(),
+                            ));
+                        }
+                        if !resolved.is_dir() {
+                            return ParseResult::Err(format!(
+                                "Project path is not a directory: {}\n\
+                                 Usage: /add <agent> --project <path>",
+                                resolved.display(),
+                            ));
+                        }
+                        project = Some(resolved.to_string_lossy().to_string());
+                        i += 2;
+                    }
                     None => return ParseResult::Err(
                         "--project requires a path\n\
                          Usage: /add <agent> --project <path>".to_string(),
@@ -941,12 +966,13 @@ mod tests {
 
     #[test]
     fn test_parse_add_with_project() {
+        // Use /tmp which always exists on macOS/Linux.
         assert_eq!(
-            parse_command_verbose("/add claude --project /tmp/myapp"),
+            parse_command_verbose("/add claude --project /tmp"),
             ParseResult::Ok(Command::AddAgent {
                 agent: "claude".to_string(),
                 image: None,
-                project: Some("/tmp/myapp".to_string()),
+                project: Some("/tmp".to_string()),
                 branch: None,
                 name: None,
                 auto_mode: false,
@@ -959,11 +985,11 @@ mod tests {
     #[test]
     fn test_parse_add_with_project_and_branch() {
         assert_eq!(
-            parse_command_verbose("/add claude --project /tmp/myapp --branch feat/auth"),
+            parse_command_verbose("/add claude --project /tmp --branch feat/auth"),
             ParseResult::Ok(Command::AddAgent {
                 agent: "claude".to_string(),
                 image: None,
-                project: Some("/tmp/myapp".to_string()),
+                project: Some("/tmp".to_string()),
                 branch: Some("feat/auth".to_string()),
                 name: None,
                 auto_mode: false,
@@ -971,6 +997,25 @@ mod tests {
                 model: None,
             })
         );
+    }
+
+    #[test]
+    fn test_parse_add_project_path_not_exists() {
+        let result = parse_command_verbose("/add claude --project /nonexistent/path/xyz");
+        assert!(matches!(result, ParseResult::Err(msg) if msg.contains("does not exist")));
+    }
+
+    #[test]
+    fn test_parse_add_project_path_not_directory() {
+        // /etc/hosts is a file, not a directory.
+        let result = parse_command_verbose("/add claude --project /etc/hosts");
+        assert!(matches!(result, ParseResult::Err(msg) if msg.contains("not a directory")));
+    }
+
+    #[test]
+    fn test_parse_add_project_missing_value() {
+        let result = parse_command_verbose("/add claude --project");
+        assert!(matches!(result, ParseResult::Err(msg) if msg.contains("--project requires a path")));
     }
 
     #[test]

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -531,6 +531,15 @@ pub async fn run_tui(
                         app.status_message = None;
                     }
                 }
+
+                // Tick down auto-dismiss system message popup.
+                if let Some(ref mut ticks) = app.system_message_ticks {
+                    *ticks = ticks.saturating_sub(1);
+                    if *ticks == 0 {
+                        app.system_messages.clear();
+                        app.system_message_ticks = None;
+                    }
+                }
                 app.sidebar_tick_counter = app.sidebar_tick_counter.wrapping_add(1);
                 if app.sidebar_tick_counter.is_multiple_of(8) {
                     // Refresh file lists when sidebar is visible (~every 2s).
@@ -1095,7 +1104,8 @@ async fn handle_key_event(
                         // Forward everything else to SSH terminal.
                         let bytes = super::terminal::crossterm_key_to_bytes(key);
                         if !bytes.is_empty() {
-                            if let Some(panel) = app.panels.get(app.focused_panel) {
+                            if let Some(panel) = app.panels.get_mut(app.focused_panel) {
+                                panel.had_interaction = true;
                                 if let Some(ref handle) = panel.terminal_handle {
                                     let _ = handle.write_tx.send(bytes);
                                 }
@@ -1164,6 +1174,7 @@ async fn handle_key_event(
         KeyCode::Esc => {
             if !app.system_messages.is_empty() && !app.panels.is_empty() {
                 app.system_messages.clear();
+                app.system_message_ticks = None;
             } else if app.autocomplete_index.is_some() {
                 app.autocomplete_index = None;
             } else if app.input_focus == InputFocus::Panel {
@@ -1227,10 +1238,14 @@ async fn handle_key_event(
                     handle_command(app, cmd, tx).await;
                 }
                 SubmitResult::CommandError(msg) => {
-                    app.set_system_message(ChatMessage {
-                        role: MessageRole::System,
-                        content: msg,
-                    });
+                    // 4 ticks × 250ms = 1s auto-dismiss; ESC still dismisses immediately.
+                    app.set_system_message_timed(
+                        ChatMessage {
+                            role: MessageRole::System,
+                            content: msg,
+                        },
+                        4,
+                    );
                 }
                 SubmitResult::Message(_msg) => {
                     // Panels are terminal-only; messages are not sent.
@@ -3155,6 +3170,17 @@ fn resume_session(
         // creating a new one. We set config.project = None so that
         // setup_project_mount() inside Sandbox::create() is skipped, and add
         // the VirtioFS mount for the existing clone ourselves.
+        //
+        // Use the per-panel project path from the saved config (which may
+        // differ from the global session.project_path when `/add --project`
+        // pointed to a different directory).
+        let panel_project_path = sp
+            .config
+            .project
+            .as_ref()
+            .map(|p| p.path.clone())
+            .unwrap_or_else(|| session.project_path.clone());
+
         if let Some(ref clone_path) = sp.clone_path {
             if clone_path.exists() {
                 // Add VirtioFS mount for existing clone directly.
@@ -3163,14 +3189,14 @@ fn resume_session(
                 config.project = None;
 
                 // Create a ProjectMount on the panel to handle suspend/teardown.
-                if let Ok(mut pm) = nanosandbox::project::ProjectMount::detect(&session.project_path) {
+                if let Ok(mut pm) = nanosandbox::project::ProjectMount::detect(&panel_project_path) {
                     let _ = pm.resume(clone_path, sp.branches.clone());
                     panel.project_mount = Some(pm);
                 }
             } else {
                 // Clone dir is gone — create a fresh clone from the branch.
                 config.project = Some(nanosandbox::ProjectConfig {
-                    path: session.project_path.clone(),
+                    path: panel_project_path,
                     branch: sp
                         .branches
                         .first()
@@ -3181,10 +3207,11 @@ fn resume_session(
             }
         }
 
-        // Mark panel as resumed so agent uses resume command variant.
-        // Agent state is stored in /workspace/.nanosb-state/ (inside the clone),
-        // so it's automatically available when the clone is re-mounted.
-        panel.is_resumed = true;
+        // Only pass resume flags (--continue, -c, etc.) if the user actually
+        // interacted with the agent in the previous session. Without this check,
+        // agents like cursor-agent fail with "No previous chats found" when
+        // resumed after being started but never used.
+        panel.is_resumed = sp.had_interaction;
 
         app.panels.push(panel);
         let panel_idx = app.panels.len() - 1;
@@ -3548,6 +3575,7 @@ fn build_session_from_app(
                 model: panel.model.clone(),
                 env_keys,
                 visible: panel.visible,
+                had_interaction: panel.had_interaction,
             })
         })
         .collect();


### PR DESCRIPTION
… resume

- Validate --project path at parse time: check exists and is directory
- Auto-dismiss command error popups after 1s (ESC still works)
- Fix per-panel project path on session resume (use config path, not global)
- Track had_interaction to only pass --continue when agent was actually used
- Fixes cursor-agent "No previous chats found" on resume without interaction