### PR TITLE
Support non-git projects for session persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,6 +2691,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2707,7 @@ checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3413,6 +3423,7 @@ dependencies = [
  "libkrun-sys",
  "log",
  "oci-distribution",
+ "openssl",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,10 +381,7 @@ mod cli {
                 // Auto-load .env from project directory (lowest priority).
                 // Check --project flag first, then CWD if it's a git repo.
                 let auto_env_dir = cli.project.as_ref().map(std::path::PathBuf::from)
-                    .or_else(|| {
-                        let cwd = std::env::current_dir().ok()?;
-                        if cwd.join(".git").exists() { Some(cwd) } else { None }
-                    });
+                    .or_else(|| std::env::current_dir().ok());
                 if let Some(ref dir) = auto_env_dir {
                     let env_path = dir.join(".env");
                     if env_path.exists() {
@@ -445,17 +442,11 @@ mod cli {
                     sandbox_configs
                 };
 
-                // Project path for sandboxes without explicit project config.
+                // Always use CWD as project path so non-git directories get session
+                // persistence and project mounting (git is initialised in source on first use).
                 let project_path = cli.project
                     .map(std::path::PathBuf::from)
-                    .or_else(|| {
-                        let cwd = std::env::current_dir().ok()?;
-                        if cwd.join(".git").exists() {
-                            Some(cwd)
-                        } else {
-                            None
-                        }
-                    });
+                    .or_else(|| std::env::current_dir().ok());
 
                 nanosb_cli::tui::run::run_tui(project_path, sandbox_configs).await
             }


### PR DESCRIPTION
## Summary

- Remove `.git` directory requirement for project path — always use cwd so non-git directories get session persistence and project mounting
- Switch to progress-aware sandbox creation (`create_with_progress` / `create_with_manager_progress`) for better TUI status feedback during image pull and VM boot
- Update validation import paths to `nanosandbox::runtime::validation::`
- Add Windows install script (`windows.ps1`)

## Changes

| File | Description |
|------|-------------|
| `src/main.rs` | Remove `.git` check, use cwd as project path; update validation imports |
| `src/tui/run.rs` | Use progress callbacks for sandbox creation (3 call sites); update validation imports |
| `scripts/install/windows.ps1` | New Windows installer |

## Cross-repo impact

None — all required runtime APIs already exist on `feature/install-deps`.

## Test plan

- [ ] Launch `nanosb` in a directory without `.git` — session persists across restarts
- [ ] Launch in a git repo — still works as before
- [ ] TUI shows progress messages during sandbox creation

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)