### PR TITLE
feat: secrets encrypted pipeline + Windows install fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2208,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libkrun"
 version = "1.17.3"
 dependencies = [
@@ -2249,6 +2274,18 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3607,6 +3644,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs",
+ "git2",
  "glob",
  "rand 0.8.5",
  "runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,27 +147,12 @@ dependencies = [
 name = "arch"
 version = "0.1.0"
 dependencies = [
- "arch_gen 0.1.0",
+ "arch_gen",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
- "smbios 0.1.0",
- "utils 0.1.0",
- "vm-memory",
- "vmm-sys-util",
-]
-
-[[package]]
-name = "arch"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "arch_gen 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "kvm-bindings",
- "kvm-ioctls",
- "libc",
- "smbios 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "utils 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "smbios",
+ "utils",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -175,11 +160,6 @@ dependencies = [
 [[package]]
 name = "arch_gen"
 version = "0.1.0"
-
-[[package]]
-name = "arch_gen"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
 
 [[package]]
 name = "argon2"
@@ -697,16 +677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "kvm-bindings",
- "kvm-ioctls",
- "vmm-sys-util",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array 0.14.7",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -947,11 +918,11 @@ dependencies = [
 name = "devices"
 version = "0.1.0"
 dependencies = [
- "arch 0.1.0",
+ "arch",
  "bitflags 1.3.2",
  "caps",
  "crossbeam-channel",
- "hvf 0.1.0",
+ "hvf",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
@@ -959,35 +930,9 @@ dependencies = [
  "log",
  "lru 0.16.3",
  "nix 0.30.1",
- "polly 0.0.1",
+ "polly",
  "rand 0.9.3",
- "utils 0.1.0",
- "virtio-bindings",
- "vm-fdt",
- "vm-memory",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "devices"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "arch 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "bitflags 1.3.2",
- "caps",
- "crossbeam-channel",
- "hvf 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "kvm-bindings",
- "kvm-ioctls",
- "libc",
- "libloading",
- "log",
- "lru 0.12.5",
- "nix 0.30.1",
- "polly 0.0.1 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "rand 0.9.3",
- "utils 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "utils",
  "virtio-bindings",
  "vm-fdt",
  "vm-memory",
@@ -1515,6 +1460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,17 +1555,6 @@ dependencies = [
 [[package]]
 name = "hcs"
 version = "0.1.0"
-dependencies = [
- "flate2",
- "log",
- "serde_json",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "hcs"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
 dependencies = [
  "flate2",
  "log",
@@ -1725,18 +1665,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 name = "hvf"
 version = "0.1.0"
 dependencies = [
- "arch 0.1.0",
- "crossbeam-channel",
- "libloading",
- "log",
-]
-
-[[package]]
-name = "hvf"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "arch 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "arch",
  "crossbeam-channel",
  "libloading",
  "log",
@@ -2153,16 +2082,7 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
- "utils 0.1.0",
- "vm-memory",
-]
-
-[[package]]
-name = "kernel"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "utils 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "utils",
  "vm-memory",
 ]
 
@@ -2279,42 +2199,20 @@ name = "libkrun"
 version = "1.17.3"
 dependencies = [
  "crossbeam-channel",
- "devices 0.1.0",
+ "devices",
  "env_logger",
- "hvf 0.1.0",
+ "hvf",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
  "libloading",
  "log",
  "once_cell",
- "polly 0.0.1",
+ "polly",
  "rand 0.9.3",
- "utils 0.1.0",
+ "utils",
  "vm-memory",
- "vmm 0.1.0",
-]
-
-[[package]]
-name = "libkrun"
-version = "1.17.3"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "crossbeam-channel",
- "devices 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "env_logger",
- "hvf 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "kvm-bindings",
- "kvm-ioctls",
- "libc",
- "libloading",
- "log",
- "once_cell",
- "polly 0.0.1 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "rand 0.9.3",
- "utils 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "vm-memory",
- "vmm 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "vmm",
 ]
 
 [[package]]
@@ -2322,16 +2220,7 @@ name = "libkrun-sys"
 version = "0.1.0"
 dependencies = [
  "libc",
- "libkrun 1.17.3",
-]
-
-[[package]]
-name = "libkrun-sys"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "libc",
- "libkrun 1.17.3 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "libkrun",
 ]
 
 [[package]]
@@ -2492,6 +2381,7 @@ dependencies = [
  "arboard",
  "assert_cmd",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "colored",
@@ -2503,7 +2393,7 @@ dependencies = [
  "png 0.17.16",
  "predicates",
  "ratatui",
- "runtime 0.1.0",
+ "runtime",
  "russh",
  "sandbox",
  "serde",
@@ -3091,16 +2981,7 @@ name = "polly"
 version = "0.0.1"
 dependencies = [
  "libc",
- "utils 0.1.0",
-]
-
-[[package]]
-name = "polly"
-version = "0.0.1"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "libc",
- "utils 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "utils",
 ]
 
 [[package]]
@@ -3539,18 +3420,21 @@ dependencies = [
 name = "runtime"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "dirs",
  "docker_credential",
  "env_logger",
  "flate2",
  "libc",
- "libkrun-sys 0.1.0",
+ "libkrun-sys",
  "log",
  "oci-distribution",
  "openssl",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3559,33 +3443,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "runtime"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "dirs",
- "docker_credential",
- "env_logger",
- "flate2",
- "libc",
- "libkrun-sys 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "log",
- "oci-distribution",
- "openssl",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tar",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "uuid",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -3744,10 +3602,14 @@ dependencies = [
 name = "sandbox"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "dirs",
- "runtime 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "glob",
+ "rand 0.8.5",
+ "runtime",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3758,6 +3620,7 @@ dependencies = [
  "tracing",
  "unicode-width 0.2.0",
  "uuid",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -4047,14 +3910,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smbios"
 version = "0.1.0"
-dependencies = [
- "vm-memory",
-]
-
-[[package]]
-name = "smbios"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
 dependencies = [
  "vm-memory",
 ]
@@ -4777,21 +4632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utils"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "bitflags 1.3.2",
- "crossbeam-channel",
- "kvm-bindings",
- "libc",
- "log",
- "nix 0.30.1",
- "vmm-sys-util",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "uuid"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4845,53 +4685,24 @@ dependencies = [
 name = "vmm"
 version = "0.1.0"
 dependencies = [
- "arch 0.1.0",
- "arch_gen 0.1.0",
+ "arch",
+ "arch_gen",
  "bzip2",
- "cpuid 0.1.0",
+ "cpuid",
  "crossbeam-channel",
- "devices 0.1.0",
+ "devices",
  "flate2",
- "hcs 0.1.0",
- "hvf 0.1.0",
- "kernel 0.1.0",
+ "hcs",
+ "hvf",
+ "kernel",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
  "linux-loader",
  "log",
  "nix 0.30.1",
- "polly 0.0.1",
- "utils 0.1.0",
- "vm-memory",
- "vmm-sys-util",
- "windows-sys 0.59.0",
- "zstd",
-]
-
-[[package]]
-name = "vmm"
-version = "0.1.0"
-source = "git+https://github.com/nanosandboxai/runtime.git?branch=main#6c1053fd3abecc57d90c306871ab8dfcd346d220"
-dependencies = [
- "arch 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "arch_gen 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "bzip2",
- "cpuid 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "crossbeam-channel",
- "devices 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "flate2",
- "hcs 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "hvf 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "kernel 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "kvm-bindings",
- "kvm-ioctls",
- "libc",
- "linux-loader",
- "log",
- "nix 0.30.1",
- "polly 0.0.1 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
- "utils 0.1.0 (git+https://github.com/nanosandboxai/runtime.git?branch=main)",
+ "polly",
+ "utils",
  "vm-memory",
  "vmm-sys-util",
  "windows-sys 0.59.0",
@@ -5518,6 +5329,18 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "xattr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
+ "chrono",
+ "rand 0.8.5",
+ "runtime",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,10 +3475,8 @@ dependencies = [
 name = "runtime"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
  "anyhow",
  "async-trait",
- "base64 0.22.1",
  "chrono",
  "dirs",
  "docker_credential",
@@ -3471,7 +3487,6 @@ dependencies = [
  "log",
  "oci-distribution",
  "openssl",
- "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3480,7 +3495,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
- "x25519-dalek",
 ]
 
 [[package]]
@@ -3639,14 +3653,12 @@ dependencies = [
 name = "sandbox"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
  "anyhow",
- "base64 0.22.1",
  "chrono",
  "dirs",
+ "gateway",
  "git2",
  "glob",
- "rand 0.8.5",
  "runtime",
  "serde",
  "serde_json",
@@ -3658,7 +3670,6 @@ dependencies = [
  "tracing",
  "unicode-width 0.2.0",
  "uuid",
- "x25519-dalek",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ arboard = "3.6"
 png = "0.17"
 
 # Utilities
+base64 = "0.22"
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 unicode-width = "0.2"
@@ -68,6 +69,11 @@ predicates = "3"
 # This is needed because the CLI is outside the runtime workspace which has its own patch.
 [patch.crates-io]
 vm-memory = { path = "../runtime/deps/libkrun/src/vm-memory-win" }
+
+# Redirect runtime git URL to local path so the sandbox crate (which depends on
+# runtime via git) uses the same local version as the CLI itself.
+[patch.'https://github.com/nanosandboxai/runtime.git']
+runtime = { path = "../runtime/crates/runtime" }
 
 [profile.release]
 lto = true

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -156,7 +156,14 @@ function Install-NanosandboxCLI {
         } else {
             Write-Info "Installing WSL2..."
             try {
-                & $wslExe --install --no-launch 2>&1 | ForEach-Object { Write-Host "  $_" }
+                if (Test-Path $wslExe) {
+                    # wsl.exe exists but WSL2 kernel isn't ready — use it directly.
+                    & $wslExe --install --no-launch 2>&1 | ForEach-Object { Write-Host "  $_" }
+                } else {
+                    # wsl.exe doesn't exist yet — enable the Windows features first.
+                    dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart | Out-Null
+                    dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart | Out-Null
+                }
                 Write-Ok "WSL2 installed"
                 $rebootNeeded = $true
             } catch {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,7 +5,7 @@
 
 .DESCRIPTION
     Downloads and installs the nanosb CLI binary and runtime dependencies on Windows.
-    1. Checks prerequisites (Hyper-V, WSL2) and installs WSL2 if missing
+    1. Checks prerequisites (Hyper-V, WHPX, WSL2, VirtualMachinePlatform) and enables missing features
     2. Downloads the nanosb.exe binary from GitHub Releases
     3. Installs runtime dependencies via install-deps
     4. Adds the install directory to the user PATH
@@ -68,7 +68,8 @@ function Install-NanosandboxCLI {
 
     # --- Windows prerequisites ---
     # Enable all required features in one pass, then do a single reboot if needed.
-    # Features required: Hyper-V, Windows Hypervisor Platform (WHPX), WSL2.
+    # Features required: Hyper-V, Windows Hypervisor Platform (WHPX),
+    # Windows Subsystem for Linux, Virtual Machine Platform (WSL2).
     # VC++ Redistributable is installed inline (no reboot needed).
     $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
         [Security.Principal.WindowsBuiltInRole]::Administrator)
@@ -135,40 +136,44 @@ function Install-NanosandboxCLI {
         Write-Ok "Visual C++ Redistributable installed"
     }
 
-    # -- WSL2 --
+    # -- WSL2 (two Windows features: WSL + Virtual Machine Platform) --
     if (-not $SkipWsl2Check) {
-        $wslExe = Join-Path $env:SystemRoot "System32\wsl.exe"
-        $wsl2Ready = $false
-        if (Test-Path $wslExe) {
-            # Use Start-Process to fully isolate wsl.exe — direct invocation
-            # leaks stderr as RemoteException in PS 5.1 regardless of redirects.
-            $proc = Start-Process -FilePath $wslExe -ArgumentList '--status' `
-                -Wait -PassThru -WindowStyle Hidden `
-                -RedirectStandardOutput "$env:TEMP\nanosb-wsl-out.txt" `
-                -RedirectStandardError  "$env:TEMP\nanosb-wsl-err.txt"
-            Remove-Item "$env:TEMP\nanosb-wsl-out.txt","$env:TEMP\nanosb-wsl-err.txt" -Force -ErrorAction SilentlyContinue
-            if ($proc.ExitCode -eq 0) { $wsl2Ready = $true }
-        }
-        if ($wsl2Ready) {
-            Write-Ok "WSL2 available"
-        } elseif (-not $isAdmin) {
-            Write-Warn "WSL2 is not installed (requires Administrator to fix)."
-        } else {
-            Write-Info "Installing WSL2..."
-            try {
-                if (Test-Path $wslExe) {
-                    # wsl.exe exists but WSL2 kernel isn't ready — use it directly.
-                    & $wslExe --install --no-launch 2>&1 | ForEach-Object { Write-Host "  $_" }
-                } else {
-                    # wsl.exe doesn't exist yet — enable the Windows features first.
-                    dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart | Out-Null
-                    dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart | Out-Null
+        # Check WSL subsystem feature
+        $wslFeature = Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -ErrorAction SilentlyContinue
+        if (-not $wslFeature -or $wslFeature.State -ne "Enabled") {
+            if (-not $isAdmin) {
+                Write-Warn "Windows Subsystem for Linux is not enabled (requires Administrator to fix)."
+            } else {
+                Write-Info "Enabling Windows Subsystem for Linux..."
+                try {
+                    $r = Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -All -NoRestart -ErrorAction Stop
+                    Write-Ok "Windows Subsystem for Linux enabled"
+                    if ($r.RestartNeeded) { $rebootNeeded = $true }
+                } catch {
+                    Write-Warn "Failed to enable Windows Subsystem for Linux: $_"
                 }
-                Write-Ok "WSL2 installed"
-                $rebootNeeded = $true
-            } catch {
-                Write-Warn "WSL2 installation failed: $_"
             }
+        } else {
+            Write-Ok "Windows Subsystem for Linux enabled"
+        }
+
+        # Check Virtual Machine Platform feature (required for WSL2)
+        $vmpFeature = Get-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -ErrorAction SilentlyContinue
+        if (-not $vmpFeature -or $vmpFeature.State -ne "Enabled") {
+            if (-not $isAdmin) {
+                Write-Warn "Virtual Machine Platform is not enabled (requires Administrator to fix)."
+            } else {
+                Write-Info "Enabling Virtual Machine Platform..."
+                try {
+                    $r = Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -All -NoRestart -ErrorAction Stop
+                    Write-Ok "Virtual Machine Platform enabled"
+                    if ($r.RestartNeeded) { $rebootNeeded = $true }
+                } catch {
+                    Write-Warn "Failed to enable Virtual Machine Platform: $_"
+                }
+            }
+        } else {
+            Write-Ok "Virtual Machine Platform enabled"
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,42 @@
 pub mod tui;
+
+/// Collect secrets from the SecretSource configuration.
+/// Returns a SecretPayload ready for encryption.
+pub fn collect_secrets(
+    secrets_config: &sandbox::SecretSource,
+    config_dir: &std::path::Path,
+) -> anyhow::Result<sandbox::secrets::payload::SecretPayload> {
+    use tracing::{info, warn};
+
+    let mut payload = sandbox::secrets::payload::SecretPayload::new();
+
+    // 1. Load from SOPS-encrypted file if specified
+    if let Some(ref file) = secrets_config.file {
+        let file_path = std::path::Path::new(file);
+        match sandbox::secrets::sops::decrypt_sops_file(file_path, config_dir) {
+            Ok(secrets) => {
+                for (key, value) in secrets {
+                    payload.add_secret(key, value);
+                }
+                info!("Loaded {} secrets from SOPS file: {}", payload.secrets.len(), file);
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!("Failed to decrypt SOPS file '{}': {}", file, e));
+            }
+        }
+    }
+
+    // 2. Read explicit keys from host environment (without set_var!)
+    for key in &secrets_config.keys {
+        match std::env::var(key) {
+            Ok(value) => {
+                payload.add_secret(key.clone(), value);
+            }
+            Err(_) => {
+                warn!("Secret key '{}' not found in host environment", key);
+            }
+        }
+    }
+
+    Ok(payload)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod cli {
     use std::time::Duration;
     use tokio::sync::Mutex;
     use tabled::{Table, Tabled};
-    use tracing::{error, warn};
+    use tracing::{error, info, warn};
 
     /// Output format for commands
     #[derive(Debug, Clone, Copy, ValueEnum, Default)]
@@ -616,6 +616,45 @@ mod cli {
         }
 
         Ok(vars)
+    }
+
+    /// Collect secrets from the SecretSource configuration.
+    /// Returns a SecretPayload ready for encryption.
+    fn collect_secrets(
+        secrets_config: &sandbox::SecretSource,
+        config_dir: &std::path::Path,
+    ) -> anyhow::Result<sandbox::secrets::payload::SecretPayload> {
+        let mut payload = sandbox::secrets::payload::SecretPayload::new();
+
+        // 1. Load from SOPS-encrypted file if specified
+        if let Some(ref file) = secrets_config.file {
+            let file_path = std::path::Path::new(file);
+            match sandbox::secrets::sops::decrypt_sops_file(file_path, config_dir) {
+                Ok(secrets) => {
+                    for (key, value) in secrets {
+                        payload.add_secret(key, value);
+                    }
+                    info!("Loaded {} secrets from SOPS file: {}", payload.secrets.len(), file);
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!("Failed to decrypt SOPS file '{}': {}", file, e));
+                }
+            }
+        }
+
+        // 2. Read explicit keys from host environment (without set_var!)
+        for key in &secrets_config.keys {
+            match std::env::var(key) {
+                Ok(value) => {
+                    payload.add_secret(key.clone(), value);
+                }
+                Err(_) => {
+                    warn!("Secret key '{}' not found in host environment", key);
+                }
+            }
+        }
+
+        Ok(payload)
     }
 
     /// Run a command in a new sandbox

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,7 @@ mod cli {
                     .ok()
                     .filter(|v| !v.is_empty())
                     .unwrap_or_else(|| default_level.to_string());
-                let file_filter = format!("runtime={lvl},nanosb_cli={lvl},nanosb={lvl}", lvl = file_level);
+                let file_filter = format!("runtime={lvl},nanosb_cli={lvl},nanosb={lvl},sandbox={lvl}", lvl = file_level);
                 let file_layer = fmt::layer()
                     .with_writer(file_writer)
                     .with_ansi(false)
@@ -317,7 +317,7 @@ mod cli {
                 if cli.command.is_some() && cli.verbose {
                     let stderr_layer = fmt::layer()
                         .with_writer(std::io::stderr)
-                        .with_filter(EnvFilter::new("runtime=debug,nanosb_cli=debug,nanosb=debug"));
+                        .with_filter(EnvFilter::new("runtime=debug,nanosb_cli=debug,nanosb=debug,sandbox=debug"));
 
                     tracing_subscriber::registry()
                         .with(file_layer)
@@ -332,7 +332,7 @@ mod cli {
                 _log_guard = None;
                 if cli.command.is_some() && cli.verbose {
                     tracing_subscriber::fmt()
-                        .with_env_filter("runtime=debug,nanosb_cli=debug,nanosb=debug")
+                        .with_env_filter("runtime=debug,nanosb_cli=debug,nanosb=debug,sandbox=debug")
                         .init();
                 } else {
                     let _ = env_logger::Builder::from_env(

--- a/src/main.rs
+++ b/src/main.rs
@@ -802,7 +802,9 @@ mod cli {
                 let result = {
                     let mut guard = shared.lock().await;
                     let sb = guard.as_mut().expect("sandbox exists");
-                    sb.exec(cmd, &args).await?
+                    sb.gateway()
+                        .map_err(|e| anyhow::anyhow!("Gateway not available: {}", e))?
+                        .exec(cmd, &args).await?
                 };
 
                 match format {
@@ -838,23 +840,25 @@ mod cli {
                 let exit_code = {
                     let mut guard = shared.lock().await;
                     let sb = guard.as_mut().expect("sandbox exists");
-                    sb.exec_stream(cmd, &args, |chunk| {
-                        match chunk.stream {
-                            Stream::Stdout => {
-                                let data = format!("{}\n", chunk.data);
-                                let stdout = std::io::stdout();
-                                let mut handle = stdout.lock();
-                                write_all_retry(&mut handle, data.as_bytes());
+                    sb.gateway()
+                        .map_err(|e| anyhow::anyhow!("Gateway not available: {}", e))?
+                        .exec_stream(cmd, &args, |chunk| {
+                            match chunk.stream {
+                                Stream::Stdout => {
+                                    let data = format!("{}\n", chunk.data);
+                                    let stdout = std::io::stdout();
+                                    let mut handle = stdout.lock();
+                                    write_all_retry(&mut handle, data.as_bytes());
+                                }
+                                Stream::Stderr => {
+                                    let data = format!("{}\n", chunk.data);
+                                    let stderr = std::io::stderr();
+                                    let mut handle = stderr.lock();
+                                    write_all_retry(&mut handle, data.as_bytes());
+                                }
                             }
-                            Stream::Stderr => {
-                                let data = format!("{}\n", chunk.data);
-                                let stderr = std::io::stderr();
-                                let mut handle = stderr.lock();
-                                write_all_retry(&mut handle, data.as_bytes());
-                            }
-                        }
-                    })
-                    .await?
+                        })
+                        .await?
                 };
 
                 // Clean up sandbox

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -349,6 +349,9 @@ pub struct AgentPanel {
     pub had_interaction: bool,
     /// Whether secrets were injected into this sandbox via the encrypted pipeline.
     pub secrets_active: bool,
+    /// Secret environment variables to inject via SSH channel.set_env().
+    /// Populated during sandbox creation from the secrets payload.
+    pub secrets_env: HashMap<String, String>,
     /// Overlay notification shown on top of the terminal (message, is_error, remaining ticks).
     /// Replaces previous notification; auto-dismissed after countdown reaches 0.
     pub notification: Option<(String, bool, u8)>,
@@ -394,6 +397,7 @@ impl AgentPanel {
             is_resumed: false,
             had_interaction: false,
             secrets_active: false,
+            secrets_env: HashMap::new(),
             notification: None,
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -350,6 +350,10 @@ pub struct AgentPanel {
     /// Whether secrets were injected into this sandbox via the encrypted pipeline.
     /// When true, secret-like env vars (API keys, tokens) are filtered from the SSH env.
     pub secrets_active: bool,
+    /// Secret key-value pairs from the encrypted pipeline, injected as process env at launch.
+    /// These never touch disk or shell — only set via process env at spawn time.
+    #[allow(dead_code)]
+    pub secrets_env: HashMap<String, String>,
     /// Overlay notification shown on top of the terminal (message, is_error, remaining ticks).
     /// Replaces previous notification; auto-dismissed after countdown reaches 0.
     pub notification: Option<(String, bool, u8)>,
@@ -395,6 +399,7 @@ impl AgentPanel {
             is_resumed: false,
             had_interaction: false,
             secrets_active: false,
+            secrets_env: HashMap::new(),
             notification: None,
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -349,9 +349,6 @@ pub struct AgentPanel {
     pub had_interaction: bool,
     /// Whether secrets were injected into this sandbox via the encrypted pipeline.
     pub secrets_active: bool,
-    /// Secret environment variables to inject via SSH channel.set_env().
-    /// Populated during sandbox creation from the secrets payload.
-    pub secrets_env: HashMap<String, String>,
     /// Overlay notification shown on top of the terminal (message, is_error, remaining ticks).
     /// Replaces previous notification; auto-dismissed after countdown reaches 0.
     pub notification: Option<(String, bool, u8)>,
@@ -397,7 +394,6 @@ impl AgentPanel {
             is_resumed: false,
             had_interaction: false,
             secrets_active: false,
-            secrets_env: HashMap::new(),
             notification: None,
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -347,6 +347,9 @@ pub struct AgentPanel {
     /// Whether the user sent at least one keystroke to this agent's terminal.
     /// Used to decide whether resume flags (--continue) are appropriate on next session load.
     pub had_interaction: bool,
+    /// Whether secrets were injected into this sandbox via the encrypted pipeline.
+    /// When true, secret-like env vars (API keys, tokens) are filtered from the SSH env.
+    pub secrets_active: bool,
     /// Overlay notification shown on top of the terminal (message, is_error, remaining ticks).
     /// Replaces previous notification; auto-dismissed after countdown reaches 0.
     pub notification: Option<(String, bool, u8)>,
@@ -391,6 +394,7 @@ impl AgentPanel {
             original_config: None,
             is_resumed: false,
             had_interaction: false,
+            secrets_active: false,
             notification: None,
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -348,12 +348,7 @@ pub struct AgentPanel {
     /// Used to decide whether resume flags (--continue) are appropriate on next session load.
     pub had_interaction: bool,
     /// Whether secrets were injected into this sandbox via the encrypted pipeline.
-    /// When true, secret-like env vars (API keys, tokens) are filtered from the SSH env.
     pub secrets_active: bool,
-    /// Secret key-value pairs from the encrypted pipeline, injected as process env at launch.
-    /// These never touch disk or shell — only set via process env at spawn time.
-    #[allow(dead_code)]
-    pub secrets_env: HashMap<String, String>,
     /// Overlay notification shown on top of the terminal (message, is_error, remaining ticks).
     /// Replaces previous notification; auto-dismissed after countdown reaches 0.
     pub notification: Option<(String, bool, u8)>,
@@ -399,7 +394,6 @@ impl AgentPanel {
             is_resumed: false,
             had_interaction: false,
             secrets_active: false,
-            secrets_env: HashMap::new(),
             notification: None,
         }
     }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -32,9 +32,6 @@ pub enum AppEvent {
         project_mount: Option<sandbox::ProjectMount>,
         /// Whether secrets were successfully injected into this sandbox.
         secrets_active: bool,
-        /// Decrypted secret key-value pairs from the encrypted pipeline.
-        /// Injected as process env vars at agent launch — never written to disk or shell history.
-        secrets_env: std::collections::HashMap<String, String>,
     },
     /// Sandbox creation or startup failed.
     SandboxFailed {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -32,8 +32,6 @@ pub enum AppEvent {
         project_mount: Option<sandbox::ProjectMount>,
         /// Whether secrets were successfully injected into this sandbox.
         secrets_active: bool,
-        /// Secret environment variables to inject via SSH channel.set_env().
-        secrets_env: std::collections::HashMap<String, String>,
     },
     /// Sandbox creation or startup failed.
     SandboxFailed {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -32,6 +32,9 @@ pub enum AppEvent {
         project_mount: Option<sandbox::ProjectMount>,
         /// Whether secrets were successfully injected into this sandbox.
         secrets_active: bool,
+        /// Decrypted secret key-value pairs from the encrypted pipeline.
+        /// Injected as process env vars at agent launch — never written to disk or shell history.
+        secrets_env: std::collections::HashMap<String, String>,
     },
     /// Sandbox creation or startup failed.
     SandboxFailed {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -32,6 +32,8 @@ pub enum AppEvent {
         project_mount: Option<sandbox::ProjectMount>,
         /// Whether secrets were successfully injected into this sandbox.
         secrets_active: bool,
+        /// Secret environment variables to inject via SSH channel.set_env().
+        secrets_env: std::collections::HashMap<String, String>,
     },
     /// Sandbox creation or startup failed.
     SandboxFailed {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -30,6 +30,8 @@ pub enum AppEvent {
         short_id: String,
         /// Project mount transferred from the sandbox (if any).
         project_mount: Option<sandbox::ProjectMount>,
+        /// Whether secrets were successfully injected into this sandbox.
+        secrets_active: bool,
     },
     /// Sandbox creation or startup failed.
     SandboxFailed {

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -454,7 +454,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     panel.loading_message = Some(message);
                 }
             }
-            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active } => {
+            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active, secrets_env } => {
                 // Get SSH info before storing sandbox
                 let ssh_info = {
                     let sb = sandbox.lock().await;
@@ -476,6 +476,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         panel.ssh_key_path = Some(key.clone());
                     }
                     panel.secrets_active = secrets_active;
+                    panel.secrets_env = secrets_env;
                 }
 
                 let is_auto_mode = app.panels.get(panel_idx)
@@ -522,6 +523,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         let agent_name = panel.agent_name.clone();
                         // Gateway merges secrets automatically — just pass panel env.
                         let env = panel.env.clone();
+                        let secrets_env = panel.secrets_env.clone();
                         let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                         let permissions = panel.permissions;
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
@@ -540,7 +542,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                 match super::terminal::connect_ssh(
                                     ssh_host.clone(), ssh_port, key_path.clone(),
                                     pty_cols, pty_rows,
-                                    &agent_name, &env, workdir.as_deref(),
+                                    &agent_name, &env, &secrets_env, workdir.as_deref(),
                                     permissions, false, prompt.as_deref(),
                                     is_resumed, model.as_deref(), panel_idx, tx.clone(),
                                 ).await {
@@ -2000,6 +2002,7 @@ async fn handle_command(
                     let agent_name = panel.agent_name.clone();
                     // Gateway merges secrets automatically — just pass panel env.
                     let env = panel.env.clone();
+                    let secrets_env = panel.secrets_env.clone();
                     let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                     let permissions = panel.permissions;
                     let auto_mode = panel.auto_mode;
@@ -2013,7 +2016,7 @@ async fn handle_command(
                     tokio::spawn(async move {
                         match super::terminal::connect_ssh(
                             ssh_host, ssh_port, key_path, pty_cols, pty_rows,
-                            &agent_name, &env, workdir.as_deref(),
+                            &agent_name, &env, &secrets_env, workdir.as_deref(),
                             permissions, auto_mode, prompt.as_deref(),
                             is_resumed, model.as_deref(), panel_idx, tx.clone(),
                         ).await {
@@ -4053,6 +4056,7 @@ fn add_agent(
                             short_id,
                             project_mount,
                             secrets_active: false,
+                            secrets_env: HashMap::new(),
                         });
                     }
                     Err(e) => {
@@ -4199,24 +4203,24 @@ fn add_agent_from_config(
                         let clone_path = sandbox
                             .project_mount()
                             .and_then(|pm| pm.worktree_base.clone());
-                        let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
+                        let (secrets_active, secrets_env) = if let Some(ref secrets_cfg) = secrets_cfg {
                             match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                Ok(manifest) => {
+                                Ok((manifest, secrets_env)) => {
                                     if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
                                         let bootstrap = secrets_bootstrap_content(&manifest);
                                         if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
                                             tracing::warn!("Failed to write secrets bootstrap: {}", e);
                                         }
                                     }
-                                    true
+                                    (true, secrets_env)
                                 }
                                 Err(e) => {
                                     tracing::error!("Secrets injection failed: {}", e);
-                                    false
+                                    (false, HashMap::new())
                                 }
                             }
                         } else {
-                            false
+                            (false, HashMap::new())
                         };
 
                         let project_mount = sandbox.take_project_mount();
@@ -4227,6 +4231,7 @@ fn add_agent_from_config(
                             short_id,
                             project_mount,
                             secrets_active,
+                            secrets_env,
                         });
                     }
                     Err(e) => {
@@ -4413,24 +4418,24 @@ fn resume_session(
                             let clone_path = sandbox
                                 .project_mount()
                                 .and_then(|pm| pm.worktree_base.clone());
-                            let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
+                            let (secrets_active, secrets_env) = if let Some(ref secrets_cfg) = secrets_cfg {
                                 match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                    Ok(manifest) => {
+                                    Ok((manifest, secrets_env)) => {
                                         if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
                                             let bootstrap = secrets_bootstrap_content(&manifest);
                                             if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
                                                 tracing::warn!("Failed to write secrets bootstrap: {}", e);
                                             }
                                         }
-                                        true
+                                        (true, secrets_env)
                                     }
                                     Err(e) => {
                                         tracing::error!("Secrets injection failed: {}", e);
-                                        false
+                                        (false, HashMap::new())
                                     }
                                 }
                             } else {
-                                false
+                                (false, HashMap::new())
                             };
 
                             let project_mount = sandbox.take_project_mount();
@@ -4441,6 +4446,7 @@ fn resume_session(
                                 short_id,
                                 project_mount,
                                 secrets_active,
+                                secrets_env,
                             });
                         }
                         Err(e) => {
@@ -5240,14 +5246,15 @@ fn handle_agent_info(app: &mut App, name: &str) {
 
 /// Collect, encrypt, and send secrets to the sandbox gateway.
 ///
-/// Returns the manifest describing what was injected. The gateway holds the
+/// Returns the manifest describing what was injected and the raw secret
+/// key/value map for SSH channel.set_env() injection. The gateway holds the
 /// decrypted secrets in memory and merges them into every exec call automatically.
 fn inject_secrets(
     sandbox: &mut sandbox::Sandbox,
     secrets_config: &sandbox::SecretSource,
     config_dir: &std::path::Path,
     clone_path: &Option<std::path::PathBuf>,
-) -> anyhow::Result<runtime::SecretManifest> {
+) -> anyhow::Result<(runtime::SecretManifest, HashMap<String, String>)> {
     // 1. Collect secrets from SOPS file and host env
     let mut payload = crate::collect_secrets(secrets_config, config_dir)?;
 
@@ -5268,11 +5275,14 @@ fn inject_secrets(
     }
 
     if payload.is_empty() {
-        return Ok(runtime::SecretManifest {
+        return Ok((runtime::SecretManifest {
             secrets: std::collections::HashMap::new(),
             files: std::collections::HashMap::new(),
-        });
+        }, HashMap::new()));
     }
+
+    // Clone secret values before encrypting, for SSH channel.set_env() injection.
+    let secrets_env = payload.secrets.clone();
 
     // 3. Get gateway public key
     // Deref through AgentSandbox -> SandboxInner -> runtime::Sandbox (git dep)
@@ -5300,7 +5310,7 @@ fn inject_secrets(
     let manifest = runtime_sb.send_secrets(&encrypted_json)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    Ok(manifest)
+    Ok((manifest, secrets_env))
 }
 
 /// Generate secrets access instructions for agent config files.

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -454,7 +454,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     panel.loading_message = Some(message);
                 }
             }
-            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active } => {
+            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active, secrets_env } => {
                 // Get SSH info before storing sandbox
                 let ssh_info = {
                     let sb = sandbox.lock().await;
@@ -476,6 +476,8 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         panel.ssh_key_path = Some(key.clone());
                     }
                     panel.secrets_active = secrets_active;
+                    // Store decrypted secret values for injection at agent launch.
+                    panel.secrets_env = secrets_env;
                 }
 
                 let is_auto_mode = app.panels.get(panel_idx)
@@ -487,13 +489,16 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     // No SSH needed — runs command via HvSocket/HTTP gateway.
                     if let Some(panel) = app.panels.get(panel_idx) {
                         let agent_name = panel.agent_name.clone();
-                        let env = panel.env.clone();
+                        // Merge panel env with secrets_env — secrets take priority.
+                        // secrets_env values are injected via execve() process env,
+                        // never via shell export or .env files.
+                        let mut env = panel.env.clone();
+                        env.extend(panel.secrets_env.iter().map(|(k, v)| (k.clone(), v.clone())));
                         let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                         let permissions = panel.permissions;
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
                         let is_resumed = panel.is_resumed;
                         let model = panel.model.clone();
-                        let panel_secrets_active = panel.secrets_active;
                         let tx = tx.clone();
                         tokio::spawn(async move {
                             spawn_gateway_exec(
@@ -501,7 +506,6 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                 workdir.as_deref(), permissions,
                                 prompt.as_deref(), is_resumed,
                                 model.as_deref(), panel_idx, tx,
-                                panel_secrets_active,
                             ).await;
                         });
                     }
@@ -521,13 +525,16 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     };
                     if let Some(panel) = app.panels.get(panel_idx) {
                         let agent_name = panel.agent_name.clone();
-                        let env = panel.env.clone();
+                        // Merge panel env with secrets_env — secrets take priority.
+                        // The SSH shell will receive these as export commands, but
+                        // their SOURCE is the encrypted pipeline (not .env files).
+                        let mut env = panel.env.clone();
+                        env.extend(panel.secrets_env.iter().map(|(k, v)| (k.clone(), v.clone())));
                         let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                         let permissions = panel.permissions;
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
                         let is_resumed = panel.is_resumed;
                         let model = panel.model.clone();
-                        let panel_secrets_active = panel.secrets_active;
                         let ssh_host = "127.0.0.1".to_string();
                         let tx = tx.clone();
                         tokio::spawn(async move {
@@ -544,7 +551,6 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                     &agent_name, &env, workdir.as_deref(),
                                     permissions, false, prompt.as_deref(),
                                     is_resumed, model.as_deref(), panel_idx, tx.clone(),
-                                    panel_secrets_active,
                                 ).await {
                                     Ok(handle) => {
                                         let _ = tx.send(AppEvent::SshConnected { panel_idx, handle });
@@ -1012,7 +1018,6 @@ async fn spawn_gateway_exec(
     model: Option<&str>,
     panel_idx: usize,
     tx: mpsc::UnboundedSender<AppEvent>,
-    secrets_active: bool,
 ) {
     let agent_cmd = super::terminal::agent_cli_command(
         agent_name, permissions, true, is_resumed, model,
@@ -1028,20 +1033,12 @@ async fn spawn_gateway_exec(
         }
     };
 
-    // Build environment map — panel env + agent-specific vars.
-    // When secrets were injected via the encrypted pipeline, skip secret-like
-    // env vars (API keys, tokens) so they are not also sent as plaintext.
-    let secret_suffixes = ["_KEY", "_TOKEN", "_SECRET", "_PASSWORD", "_CREDENTIAL"];
+    // Build environment map — panel env (already merged with secrets_env by the
+    // SandboxReady handler) + agent-specific vars.
+    // Secrets arrive here as regular env vars; they were set on the process via
+    // execve() by the gateway, never via shell export or .env files.
     let mut exec_env: HashMap<String, String> = env
         .iter()
-        .filter(|(k, _)| {
-            if secrets_active {
-                let upper = k.to_uppercase();
-                !secret_suffixes.iter().any(|s| upper.ends_with(s))
-            } else {
-                true
-            }
-        })
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
     exec_env.extend(super::terminal::agent_env_vars(
@@ -2011,14 +2008,15 @@ async fn handle_command(
 
                 if let Some((ssh_port, key_path)) = ssh_info {
                     let agent_name = panel.agent_name.clone();
-                    let env = panel.env.clone();
+                    // Merge panel env with secrets_env for reconnect — same as initial connect.
+                    let mut env = panel.env.clone();
+                    env.extend(panel.secrets_env.iter().map(|(k, v)| (k.clone(), v.clone())));
                     let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                     let permissions = panel.permissions;
                     let auto_mode = panel.auto_mode;
                     let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
                     let is_resumed = panel.is_resumed;
                     let model = panel.model.clone();
-                    let panel_secrets_active = panel.secrets_active;
                     // Use 127.0.0.1 on all platforms — on Windows, portproxy
                     // rules route localhost to the guest IP via HCN NAT.
                     let ssh_host = "127.0.0.1".to_string();
@@ -2029,7 +2027,6 @@ async fn handle_command(
                             &agent_name, &env, workdir.as_deref(),
                             permissions, auto_mode, prompt.as_deref(),
                             is_resumed, model.as_deref(), panel_idx, tx.clone(),
-                            panel_secrets_active,
                         ).await {
                             Ok(handle) => {
                                 let _ = tx.send(AppEvent::SshConnected { panel_idx, handle });
@@ -4067,6 +4064,7 @@ fn add_agent(
                             short_id,
                             project_mount,
                             secrets_active: false,
+                            secrets_env: HashMap::new(),
                         });
                     }
                     Err(e) => {
@@ -4213,22 +4211,22 @@ fn add_agent_from_config(
                         let clone_path = sandbox
                             .project_mount()
                             .and_then(|pm| pm.worktree_base.clone());
-                        let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
+                        let (secrets_active, secrets_env) = if let Some(ref secrets_cfg) = secrets_cfg {
                             match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                Ok(manifest) => {
+                                Ok((manifest, env_map)) => {
                                     if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
                                         let bootstrap = secrets_bootstrap_content(&manifest);
                                         let _ = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await;
                                     }
-                                    true
+                                    (true, env_map)
                                 }
                                 Err(e) => {
                                     tracing::error!("Secrets injection failed: {}", e);
-                                    false
+                                    (false, HashMap::new())
                                 }
                             }
                         } else {
-                            false
+                            (false, HashMap::new())
                         };
 
                         let project_mount = sandbox.take_project_mount();
@@ -4239,6 +4237,7 @@ fn add_agent_from_config(
                             short_id,
                             project_mount,
                             secrets_active,
+                            secrets_env,
                         });
                     }
                     Err(e) => {
@@ -4425,22 +4424,22 @@ fn resume_session(
                             let clone_path = sandbox
                                 .project_mount()
                                 .and_then(|pm| pm.worktree_base.clone());
-                            let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
+                            let (secrets_active, secrets_env) = if let Some(ref secrets_cfg) = secrets_cfg {
                                 match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                    Ok(manifest) => {
+                                    Ok((manifest, env_map)) => {
                                         if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
                                             let bootstrap = secrets_bootstrap_content(&manifest);
                                             let _ = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await;
                                         }
-                                        true
+                                        (true, env_map)
                                     }
                                     Err(e) => {
                                         tracing::error!("Secrets injection failed: {}", e);
-                                        false
+                                        (false, HashMap::new())
                                     }
                                 }
                             } else {
-                                false
+                                (false, HashMap::new())
                             };
 
                             let project_mount = sandbox.take_project_mount();
@@ -4451,6 +4450,7 @@ fn resume_session(
                                 short_id,
                                 project_mount,
                                 secrets_active,
+                                secrets_env,
                             });
                         }
                         Err(e) => {
@@ -5249,12 +5249,16 @@ fn handle_agent_info(app: &mut App, name: &str) {
 }
 
 /// Collect, encrypt, and send secrets to the sandbox gateway.
+///
+/// Returns a tuple of (manifest, secrets_env) where secrets_env contains the
+/// plaintext key-value pairs for injection as process environment variables at
+/// agent launch time. These values are never written to disk or shell history.
 fn inject_secrets(
     sandbox: &mut sandbox::Sandbox,
     secrets_config: &sandbox::SecretSource,
     config_dir: &std::path::Path,
     clone_path: &Option<std::path::PathBuf>,
-) -> anyhow::Result<runtime::SecretManifest> {
+) -> anyhow::Result<(runtime::SecretManifest, HashMap<String, String>)> {
     // 1. Collect secrets from SOPS file and host env
     let mut payload = crate::collect_secrets(secrets_config, config_dir)?;
 
@@ -5275,11 +5279,15 @@ fn inject_secrets(
     }
 
     if payload.is_empty() {
-        return Ok(runtime::SecretManifest {
+        return Ok((runtime::SecretManifest {
             secrets: std::collections::HashMap::new(),
             files: std::collections::HashMap::new(),
-        });
+        }, std::collections::HashMap::new()));
     }
+
+    // Clone the secret key-value pairs before encryption so they can be
+    // injected as process env vars at agent launch (never written to disk).
+    let secrets_env = payload.secrets.clone();
 
     // 3. Get gateway public key
     // Deref through AgentSandbox -> SandboxInner -> runtime::Sandbox (git dep)
@@ -5307,7 +5315,7 @@ fn inject_secrets(
     let manifest = runtime_sb.send_secrets(&encrypted_json)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    Ok(manifest)
+    Ok((manifest, secrets_env))
 }
 
 /// Generate secrets protocol instructions for agent config files.

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -1,7 +1,9 @@
 //! Main event loop for the TUI.
 
 use std::collections::HashMap;
+use base64::Engine;
 use std::io::{self, IsTerminal};
+use tracing::warn;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -5130,6 +5132,68 @@ fn handle_agent_info(app: &mut App, name: &str) {
         role: MessageRole::System,
         content,
     });
+}
+
+/// Collect, encrypt, and send secrets to the sandbox gateway.
+fn inject_secrets(
+    sandbox: &mut sandbox::Sandbox,
+    secrets_config: &sandbox::SecretSource,
+    config_dir: &std::path::Path,
+    clone_path: &Option<std::path::PathBuf>,
+) -> anyhow::Result<runtime::SecretManifest> {
+    // 1. Collect secrets from SOPS file and host env
+    let mut payload = crate::collect_secrets(secrets_config, config_dir)?;
+
+    // 2. Intercept sensitive files from git repo clone
+    if let Some(ref clone) = clone_path {
+        if !secrets_config.intercept_patterns.is_empty() {
+            let result = sandbox::secrets::intercept::intercept_sensitive_files(
+                clone,
+                &secrets_config.intercept_patterns,
+            );
+            for (path, contents) in result.intercepted {
+                payload.add_intercepted_file(path, contents);
+            }
+            for (path, err) in &result.errors {
+                warn!("Failed to intercept {}: {}", path, err);
+            }
+        }
+    }
+
+    if payload.is_empty() {
+        return Ok(runtime::SecretManifest {
+            secrets: std::collections::HashMap::new(),
+            files: std::collections::HashMap::new(),
+        });
+    }
+
+    // 3. Get gateway public key
+    // Deref through AgentSandbox -> SandboxInner -> runtime::Sandbox (git dep)
+    // We avoid a type annotation here because runtime appears twice in the dep graph.
+    let runtime_sb = &mut ***sandbox;
+    let pubkey_b64 = runtime_sb.secrets_pubkey()
+        .ok_or_else(|| anyhow::anyhow!("Gateway secrets pubkey not available"))?;
+
+    let pubkey_bytes: [u8; 32] = base64::engine::general_purpose::STANDARD
+        .decode(&pubkey_b64)
+        .map_err(|e| anyhow::anyhow!("Invalid gateway pubkey: {}", e))?
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Gateway pubkey must be 32 bytes"))?;
+
+    // 4. Encrypt payload
+    let plaintext = payload.to_json_bytes()
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let encrypted = sandbox::secrets::crypto::encrypt_payload(&plaintext, &pubkey_bytes)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let encrypted_json = serde_json::to_string(&encrypted)?;
+
+    // 5. Send to gateway
+    let manifest = runtime_sb.send_secrets(&encrypted_json)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    Ok(manifest)
 }
 
 #[cfg(test)]

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -4004,6 +4004,14 @@ fn add_agent(
     panel.original_config = Some(config.clone());
     panel.display_name = name.map(String::from);
 
+    // Capture panel env vars and agent-specific fields before panel is moved into app.panels.
+    let panel_env: HashMap<String, String> = panel.env.clone();
+    let agent_permissions = panel.permissions;
+    let agent_name_str = agent.to_string();
+    let agent_auto_mode = auto_mode;
+    let agent_model = model.map(String::from);
+    let agent_prompt = prompt.map(String::from);
+
     app.panels.push(panel);
     let panel_idx = app.panels.len() - 1;
     app.focused_panel = panel_idx;
@@ -4043,6 +4051,26 @@ fn add_agent(
                         if let Some(resolved) = &resolved_agent {
                             let _ = sandbox.bootstrap_agent(resolved).await;
                         }
+
+                        // Insert panel env vars (API keys, etc.) and agent-specific vars
+                        // into the runtime config.env so they're delivered via gateway POST.
+                        // Deref: AgentSandbox -> SandboxInner -> runtime::Sandbox
+                        for (key, val) in &panel_env {
+                            (**sandbox).config_mut().env.insert(key.clone(), val.clone());
+                        }
+                        for (key, val) in super::terminal::agent_env_vars(
+                            &agent_name_str,
+                            agent_permissions,
+                            agent_auto_mode,
+                            agent_model.as_deref(),
+                            agent_prompt.as_deref(),
+                        ) {
+                            (**sandbox).config_mut().env.insert(key, val);
+                        }
+                        if let Err(e) = (**sandbox).send_env_to_gateway() {
+                            tracing::warn!("Failed to send env to gateway: {}", e);
+                        }
+
                         // Take the project mount from the sandbox so we can
                         // store it on the panel for teardown on kill.
                         let project_mount = sandbox.take_project_mount();
@@ -4162,6 +4190,12 @@ fn add_agent_from_config(
     // Capture the agent type string for secrets bootstrap.
     let agent_type_str = agent_type.clone();
 
+    // Capture agent-specific fields before config is moved into the async block.
+    let agent_auto_mode = config.auto_mode;
+    let agent_permissions = config.permissions;
+    let agent_model = config.model.clone();
+    let agent_prompt = config.prompt.clone();
+
     let tx = tx.clone();
     let image_manager = app.image_manager.clone();
     tokio::spawn(async move {
@@ -4195,6 +4229,19 @@ fn add_agent_from_config(
                             let _ = sandbox.bootstrap_agent(resolved).await;
                         }
 
+                        // Merge agent-specific env vars (GOOSE_MODE, NANOSB_PROMPT, etc.)
+                        // into the runtime config.env so they're included in the gateway POST.
+                        for (key, val) in super::terminal::agent_env_vars(
+                            &agent_type_str,
+                            agent_permissions,
+                            agent_auto_mode,
+                            agent_model.as_deref(),
+                            agent_prompt.as_deref(),
+                        ) {
+                            // Deref: AgentSandbox -> SandboxInner -> runtime::Sandbox
+                            (**sandbox).config_mut().env.insert(key, val);
+                        }
+
                         // Secrets injection (lifecycle — works for both auto and interactive)
                         let clone_path = sandbox
                             .project_mount()
@@ -4216,6 +4263,10 @@ fn add_agent_from_config(
                                 }
                             }
                         } else {
+                            // No secrets config — still send env vars to gateway for SSH delivery
+                            if let Err(e) = (**sandbox).send_env_to_gateway() {
+                                tracing::warn!("Failed to send env to gateway: {}", e);
+                            }
                             false
                         };
 
@@ -4375,6 +4426,12 @@ fn resume_session(
             .unwrap_or_else(|| session.project_path.clone());
         let agent_type_str = agent_type.clone();
 
+        // Capture agent-specific fields before config is moved into the async block.
+        let agent_auto_mode = sp.auto_mode;
+        let agent_permissions = sp.permissions;
+        let agent_model = sp.model.clone();
+        let agent_prompt = sp.prompt.clone();
+
         // Spawn sandbox creation in background.
         let tx = tx.clone();
         let image_manager = app.image_manager.clone();
@@ -4409,6 +4466,19 @@ fn resume_session(
                                 let _ = sandbox.bootstrap_agent(resolved).await;
                             }
 
+                            // Merge agent-specific env vars (GOOSE_MODE, NANOSB_PROMPT, etc.)
+                            // into the runtime config.env so they're included in the gateway POST.
+                            for (key, val) in super::terminal::agent_env_vars(
+                                &agent_type_str,
+                                agent_permissions,
+                                agent_auto_mode,
+                                agent_model.as_deref(),
+                                agent_prompt.as_deref(),
+                            ) {
+                                // Deref: AgentSandbox -> SandboxInner -> runtime::Sandbox
+                                (**sandbox).config_mut().env.insert(key, val);
+                            }
+
                             // Secrets injection (lifecycle — works for both auto and interactive)
                             let clone_path = sandbox
                                 .project_mount()
@@ -4430,6 +4500,10 @@ fn resume_session(
                                     }
                                 }
                             } else {
+                                // No secrets config — still send env vars to gateway for SSH delivery
+                                if let Err(e) = (**sandbox).send_env_to_gateway() {
+                                    tracing::warn!("Failed to send env to gateway: {}", e);
+                                }
                                 false
                             };
 

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -540,6 +540,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                     &agent_name, &env, workdir.as_deref(),
                                     permissions, false, prompt.as_deref(),
                                     is_resumed, model.as_deref(), panel_idx, tx.clone(),
+                                    false,
                                 ).await {
                                     Ok(handle) => {
                                         let _ = tx.send(AppEvent::SshConnected { panel_idx, handle });
@@ -2008,6 +2009,7 @@ async fn handle_command(
                             &agent_name, &env, workdir.as_deref(),
                             permissions, auto_mode, prompt.as_deref(),
                             is_resumed, model.as_deref(), panel_idx, tx.clone(),
+                            false,
                         ).await {
                             Ok(handle) => {
                                 let _ = tx.send(AppEvent::SshConnected { panel_idx, handle });

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -4067,7 +4067,13 @@ fn add_agent(
                         ) {
                             (**sandbox).config_mut().env.insert(key, val);
                         }
-                        if let Err(e) = (**sandbox).send_env_to_gateway() {
+                        // Encrypt and send ALL env vars to gateway
+                        let clone_path = sandbox
+                            .project_mount()
+                            .and_then(|pm| pm.worktree_base.clone());
+                        if let Err(e) = send_encrypted_env(
+                            &mut sandbox, None, std::path::Path::new("."), &clone_path,
+                        ) {
                             tracing::warn!("Failed to send env to gateway: {}", e);
                         }
 
@@ -4242,32 +4248,29 @@ fn add_agent_from_config(
                             (**sandbox).config_mut().env.insert(key, val);
                         }
 
-                        // Secrets injection (lifecycle — works for both auto and interactive)
+                        // Encrypt and send ALL env vars to gateway (always — not just when secrets: is configured)
                         let clone_path = sandbox
                             .project_mount()
                             .and_then(|pm| pm.worktree_base.clone());
-                        let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
-                            match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                Ok(manifest) => {
-                                    if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
-                                        let bootstrap = secrets_bootstrap_content(&manifest);
-                                        if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
-                                            tracing::warn!("Failed to write secrets bootstrap: {}", e);
-                                        }
+                        let secrets_active = match send_encrypted_env(
+                            &mut sandbox,
+                            secrets_cfg.as_ref(),
+                            &config_dir,
+                            &clone_path,
+                        ) {
+                            Ok(manifest) => {
+                                if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
+                                    let bootstrap = secrets_bootstrap_content(&manifest);
+                                    if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
+                                        tracing::warn!("Failed to write secrets bootstrap: {}", e);
                                     }
-                                    true
                                 }
-                                Err(e) => {
-                                    tracing::error!("Secrets injection failed: {}", e);
-                                    false
-                                }
+                                true
                             }
-                        } else {
-                            // No secrets config — still send env vars to gateway for SSH delivery
-                            if let Err(e) = (**sandbox).send_env_to_gateway() {
-                                tracing::warn!("Failed to send env to gateway: {}", e);
+                            Err(e) => {
+                                tracing::error!("Failed to send env to gateway: {}", e);
+                                false
                             }
-                            false
                         };
 
                         let project_mount = sandbox.take_project_mount();
@@ -4479,32 +4482,29 @@ fn resume_session(
                                 (**sandbox).config_mut().env.insert(key, val);
                             }
 
-                            // Secrets injection (lifecycle — works for both auto and interactive)
+                            // Encrypt and send ALL env vars to gateway (always)
                             let clone_path = sandbox
                                 .project_mount()
                                 .and_then(|pm| pm.worktree_base.clone());
-                            let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
-                                match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                    Ok(manifest) => {
-                                        if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
-                                            let bootstrap = secrets_bootstrap_content(&manifest);
-                                            if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
-                                                tracing::warn!("Failed to write secrets bootstrap: {}", e);
-                                            }
+                            let secrets_active = match send_encrypted_env(
+                                &mut sandbox,
+                                secrets_cfg.as_ref(),
+                                &config_dir,
+                                &clone_path,
+                            ) {
+                                Ok(manifest) => {
+                                    if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
+                                        let bootstrap = secrets_bootstrap_content(&manifest);
+                                        if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
+                                            tracing::warn!("Failed to write secrets bootstrap: {}", e);
                                         }
-                                        true
                                     }
-                                    Err(e) => {
-                                        tracing::error!("Secrets injection failed: {}", e);
-                                        false
-                                    }
+                                    true
                                 }
-                            } else {
-                                // No secrets config — still send env vars to gateway for SSH delivery
-                                if let Err(e) = (**sandbox).send_env_to_gateway() {
-                                    tracing::warn!("Failed to send env to gateway: {}", e);
+                                Err(e) => {
+                                    tracing::error!("Failed to send env to gateway: {}", e);
+                                    false
                                 }
-                                false
                             };
 
                             let project_mount = sandbox.take_project_mount();
@@ -5312,47 +5312,65 @@ fn handle_agent_info(app: &mut App, name: &str) {
     });
 }
 
-/// Collect, encrypt, and send secrets to the sandbox gateway.
+/// Encrypt and send ALL env vars to the gateway.
 ///
-/// Returns the manifest describing what was injected. The gateway holds the
-/// decrypted secrets in memory and merges them into every exec call and SSH
-/// session automatically.
-fn inject_secrets(
+/// This is called for EVERY sandbox after start(). All env vars (from .env,
+/// sandbox.yml env:, --env flags, auto-detected API keys, agent-specific vars)
+/// are encrypted and sent to the gateway's SSH env store + secrets_store.
+///
+/// If a secrets: config is present, also collects from SOPS files and intercepts
+/// credential files from the git repo.
+///
+/// The gateway injects these into every SSH session and exec call via cmd.Env —
+/// no shell export, no .env files inside the VM.
+fn send_encrypted_env(
     sandbox: &mut sandbox::Sandbox,
-    secrets_config: &sandbox::SecretSource,
+    secrets_config: Option<&sandbox::SecretSource>,
     config_dir: &std::path::Path,
     clone_path: &Option<std::path::PathBuf>,
 ) -> anyhow::Result<runtime::SecretManifest> {
-    // 1. Collect secrets from SOPS file and host env
-    let mut payload = crate::collect_secrets(secrets_config, config_dir)?;
+    let mut payload = sandbox::secrets::payload::SecretPayload::new();
 
-    // 2. Intercept sensitive files from git repo clone
-    if let Some(ref clone) = clone_path {
-        if !secrets_config.intercept_patterns.is_empty() {
-            let result = sandbox::secrets::intercept::intercept_sensitive_files(
-                clone,
-                &secrets_config.intercept_patterns,
-            );
-            for (path, contents) in result.intercepted {
-                payload.add_intercepted_file(path, contents);
-            }
-            for (path, err) in &result.errors {
-                warn!("Failed to intercept {}: {}", path, err);
+    // 1. If secrets: config exists, collect from SOPS file and host env keys
+    if let Some(secrets_cfg) = secrets_config {
+        let extra = crate::collect_secrets(secrets_cfg, config_dir)?;
+        for (k, v) in extra.secrets {
+            payload.add_secret(k, v);
+        }
+
+        // Intercept sensitive files from git repo clone
+        if let Some(ref clone) = clone_path {
+            if !secrets_cfg.intercept_patterns.is_empty() {
+                let result = sandbox::secrets::intercept::intercept_sensitive_files(
+                    clone,
+                    &secrets_cfg.intercept_patterns,
+                );
+                for (path, contents) in result.intercepted {
+                    payload.add_intercepted_file(path, contents);
+                }
+                for (path, err) in &result.errors {
+                    warn!("Failed to intercept {}: {}", path, err);
+                }
             }
         }
     }
 
-    if payload.is_empty() {
+    // 2. Add ALL config.env vars to the payload
+    let runtime_sb = &mut ***sandbox;
+    for (k, v) in &runtime_sb.config().env {
+        if !payload.secrets.contains_key(k) {
+            payload.add_secret(k.clone(), v.clone());
+        }
+    }
+
+    if payload.secrets.is_empty() && payload.intercepted_files.is_empty() {
         return Ok(runtime::SecretManifest {
             secrets: std::collections::HashMap::new(),
             files: std::collections::HashMap::new(),
         });
     }
 
-    // 3. Get gateway public key
-    // Deref through AgentSandbox -> SandboxInner -> runtime::Sandbox (git dep)
-    // We avoid a type annotation here because runtime appears twice in the dep graph.
-    let runtime_sb = &mut ***sandbox;
+    // 3. Encrypt using the RUNTIME's crypto (same crate as decrypt — no version mismatch)
     let pubkey_b64 = runtime_sb.secrets_pubkey()
         .ok_or_else(|| anyhow::anyhow!("Gateway secrets pubkey not available"))?;
 
@@ -5362,16 +5380,15 @@ fn inject_secrets(
         .try_into()
         .map_err(|_| anyhow::anyhow!("Gateway pubkey must be 32 bytes"))?;
 
-    // 4. Encrypt payload
     let plaintext = payload.to_json_bytes()
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    let encrypted = sandbox::secrets::crypto::encrypt_payload(&plaintext, &pubkey_bytes)
+    let encrypted = runtime::encrypt_payload(&plaintext, &pubkey_bytes)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let encrypted_json = serde_json::to_string(&encrypted)?;
 
-    // 5. Send to gateway
+    // 4. Send encrypted payload → runtime decrypts → stores in secrets_store + POSTs to gateway
     let manifest = runtime_sb.send_secrets(&encrypted_json)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -4101,7 +4101,17 @@ fn add_agent_from_config(
     for (api_key, _) in &required_api_keys(&agent_type) {
         if !panel.env.contains_key(*api_key) {
             if let Ok(val) = std::env::var(api_key) {
-                panel.env.insert(api_key.to_string(), val);
+                if config.secrets.is_some() {
+                    // Route through encrypted secrets pipeline
+                    if let Some(ref mut secrets) = config.secrets {
+                        if !secrets.keys.contains(&api_key.to_string()) {
+                            secrets.keys.push(api_key.to_string());
+                        }
+                    }
+                } else {
+                    // Legacy path: add to env
+                    panel.env.insert(api_key.to_string(), val);
+                }
             }
         }
     }
@@ -4241,7 +4251,17 @@ fn resume_session(
         for (api_key, _) in &required_api_keys(&agent_type) {
             if !panel.env.contains_key(*api_key) {
                 if let Ok(val) = std::env::var(api_key) {
-                    panel.env.insert(api_key.to_string(), val);
+                    if config.secrets.is_some() {
+                        // Route through encrypted secrets pipeline
+                        if let Some(ref mut secrets) = config.secrets {
+                            if !secrets.keys.contains(&api_key.to_string()) {
+                                secrets.keys.push(api_key.to_string());
+                            }
+                        }
+                    } else {
+                        // Legacy path: add to env
+                        panel.env.insert(api_key.to_string(), val);
+                    }
                 }
             }
         }

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -454,7 +454,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     panel.loading_message = Some(message);
                 }
             }
-            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active, secrets_env } => {
+            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active } => {
                 // Get SSH info before storing sandbox
                 let ssh_info = {
                     let sb = sandbox.lock().await;
@@ -476,8 +476,6 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         panel.ssh_key_path = Some(key.clone());
                     }
                     panel.secrets_active = secrets_active;
-                    // Store decrypted secret values for injection at agent launch.
-                    panel.secrets_env = secrets_env;
                 }
 
                 let is_auto_mode = app.panels.get(panel_idx)
@@ -489,11 +487,8 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     // No SSH needed — runs command via HvSocket/HTTP gateway.
                     if let Some(panel) = app.panels.get(panel_idx) {
                         let agent_name = panel.agent_name.clone();
-                        // Merge panel env with secrets_env — secrets take priority.
-                        // secrets_env values are injected via execve() process env,
-                        // never via shell export or .env files.
-                        let mut env = panel.env.clone();
-                        env.extend(panel.secrets_env.iter().map(|(k, v)| (k.clone(), v.clone())));
+                        // Gateway merges secrets automatically — just pass panel env.
+                        let env = panel.env.clone();
                         let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                         let permissions = panel.permissions;
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
@@ -525,11 +520,8 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     };
                     if let Some(panel) = app.panels.get(panel_idx) {
                         let agent_name = panel.agent_name.clone();
-                        // Merge panel env with secrets_env — secrets take priority.
-                        // The SSH shell will receive these as export commands, but
-                        // their SOURCE is the encrypted pipeline (not .env files).
-                        let mut env = panel.env.clone();
-                        env.extend(panel.secrets_env.iter().map(|(k, v)| (k.clone(), v.clone())));
+                        // Gateway merges secrets automatically — just pass panel env.
+                        let env = panel.env.clone();
                         let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                         let permissions = panel.permissions;
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
@@ -1033,10 +1025,8 @@ async fn spawn_gateway_exec(
         }
     };
 
-    // Build environment map — panel env (already merged with secrets_env by the
-    // SandboxReady handler) + agent-specific vars.
-    // Secrets arrive here as regular env vars; they were set on the process via
-    // execve() by the gateway, never via shell export or .env files.
+    // Build environment map — panel env + agent-specific vars.
+    // Secrets are injected by the gateway automatically via exec_with_options.
     let mut exec_env: HashMap<String, String> = env
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
@@ -2008,9 +1998,8 @@ async fn handle_command(
 
                 if let Some((ssh_port, key_path)) = ssh_info {
                     let agent_name = panel.agent_name.clone();
-                    // Merge panel env with secrets_env for reconnect — same as initial connect.
-                    let mut env = panel.env.clone();
-                    env.extend(panel.secrets_env.iter().map(|(k, v)| (k.clone(), v.clone())));
+                    // Gateway merges secrets automatically — just pass panel env.
+                    let env = panel.env.clone();
                     let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                     let permissions = panel.permissions;
                     let auto_mode = panel.auto_mode;
@@ -4064,7 +4053,6 @@ fn add_agent(
                             short_id,
                             project_mount,
                             secrets_active: false,
-                            secrets_env: HashMap::new(),
                         });
                     }
                     Err(e) => {
@@ -4211,22 +4199,24 @@ fn add_agent_from_config(
                         let clone_path = sandbox
                             .project_mount()
                             .and_then(|pm| pm.worktree_base.clone());
-                        let (secrets_active, secrets_env) = if let Some(ref secrets_cfg) = secrets_cfg {
+                        let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
                             match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                Ok((manifest, env_map)) => {
+                                Ok(manifest) => {
                                     if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
                                         let bootstrap = secrets_bootstrap_content(&manifest);
-                                        let _ = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await;
+                                        if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
+                                            tracing::warn!("Failed to write secrets bootstrap: {}", e);
+                                        }
                                     }
-                                    (true, env_map)
+                                    true
                                 }
                                 Err(e) => {
                                     tracing::error!("Secrets injection failed: {}", e);
-                                    (false, HashMap::new())
+                                    false
                                 }
                             }
                         } else {
-                            (false, HashMap::new())
+                            false
                         };
 
                         let project_mount = sandbox.take_project_mount();
@@ -4237,7 +4227,6 @@ fn add_agent_from_config(
                             short_id,
                             project_mount,
                             secrets_active,
-                            secrets_env,
                         });
                     }
                     Err(e) => {
@@ -4424,22 +4413,24 @@ fn resume_session(
                             let clone_path = sandbox
                                 .project_mount()
                                 .and_then(|pm| pm.worktree_base.clone());
-                            let (secrets_active, secrets_env) = if let Some(ref secrets_cfg) = secrets_cfg {
+                            let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
                                 match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                    Ok((manifest, env_map)) => {
+                                    Ok(manifest) => {
                                         if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
                                             let bootstrap = secrets_bootstrap_content(&manifest);
-                                            let _ = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await;
+                                            if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
+                                                tracing::warn!("Failed to write secrets bootstrap: {}", e);
+                                            }
                                         }
-                                        (true, env_map)
+                                        true
                                     }
                                     Err(e) => {
                                         tracing::error!("Secrets injection failed: {}", e);
-                                        (false, HashMap::new())
+                                        false
                                     }
                                 }
                             } else {
-                                (false, HashMap::new())
+                                false
                             };
 
                             let project_mount = sandbox.take_project_mount();
@@ -4450,7 +4441,6 @@ fn resume_session(
                                 short_id,
                                 project_mount,
                                 secrets_active,
-                                secrets_env,
                             });
                         }
                         Err(e) => {
@@ -5250,15 +5240,14 @@ fn handle_agent_info(app: &mut App, name: &str) {
 
 /// Collect, encrypt, and send secrets to the sandbox gateway.
 ///
-/// Returns a tuple of (manifest, secrets_env) where secrets_env contains the
-/// plaintext key-value pairs for injection as process environment variables at
-/// agent launch time. These values are never written to disk or shell history.
+/// Returns the manifest describing what was injected. The gateway holds the
+/// decrypted secrets in memory and merges them into every exec call automatically.
 fn inject_secrets(
     sandbox: &mut sandbox::Sandbox,
     secrets_config: &sandbox::SecretSource,
     config_dir: &std::path::Path,
     clone_path: &Option<std::path::PathBuf>,
-) -> anyhow::Result<(runtime::SecretManifest, HashMap<String, String>)> {
+) -> anyhow::Result<runtime::SecretManifest> {
     // 1. Collect secrets from SOPS file and host env
     let mut payload = crate::collect_secrets(secrets_config, config_dir)?;
 
@@ -5279,15 +5268,11 @@ fn inject_secrets(
     }
 
     if payload.is_empty() {
-        return Ok((runtime::SecretManifest {
+        return Ok(runtime::SecretManifest {
             secrets: std::collections::HashMap::new(),
             files: std::collections::HashMap::new(),
-        }, std::collections::HashMap::new()));
+        });
     }
-
-    // Clone the secret key-value pairs before encryption so they can be
-    // injected as process env vars at agent launch (never written to disk).
-    let secrets_env = payload.secrets.clone();
 
     // 3. Get gateway public key
     // Deref through AgentSandbox -> SandboxInner -> runtime::Sandbox (git dep)
@@ -5315,52 +5300,44 @@ fn inject_secrets(
     let manifest = runtime_sb.send_secrets(&encrypted_json)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    Ok((manifest, secrets_env))
+    Ok(manifest)
 }
 
-/// Generate secrets protocol instructions for agent config files.
-#[allow(dead_code)]
+/// Generate secrets access instructions for agent config files.
 fn secrets_bootstrap_content(manifest: &runtime::SecretManifest) -> String {
     let mut lines = Vec::new();
-    lines.push("## Secrets Access Protocol".to_string());
+    lines.push("## Secrets Access".to_string());
     lines.push(String::new());
-    lines.push("All secrets and credentials in this workspace are managed by nanosb-secret.".to_string());
-    lines.push("Do NOT read .env files, environment variables, or any credential files directly.".to_string());
-    lines.push(String::new());
-    lines.push("Available commands:".to_string());
-    lines.push("- `nanosb-secret list` — list available secret key names".to_string());
-    lines.push("- `nanosb-secret read <KEY>` — read a secret value".to_string());
-    lines.push("- `nanosb-secret file <FILENAME>` — read an intercepted file's contents".to_string());
-    lines.push("- `nanosb-secret export <KEY> <PATH>` — write secret to a file for tools that need a file path".to_string());
+    lines.push("The following secrets are available as environment variables in this session.".to_string());
+    lines.push("Do NOT hardcode these values. Read them from the environment when needed.".to_string());
     lines.push(String::new());
 
     if !manifest.secrets.is_empty() {
         let mut keys: Vec<&String> = manifest.secrets.keys().collect();
         keys.sort();
         lines.push(format!(
-            "Available secret keys: {}",
-            keys.iter().map(|k| format!("`{}`", k)).collect::<Vec<_>>().join(", ")
+            "Available secret env vars: {}",
+            keys.iter().map(|k| format!("`${}`", k)).collect::<Vec<_>>().join(", ")
         ));
     }
 
     if !manifest.files.is_empty() {
-        let mut files: Vec<&String> = manifest.files.keys().collect();
-        files.sort();
-        lines.push(format!(
-            "Intercepted files: {}",
-            files.iter().map(|f| format!("`{}`", f)).collect::<Vec<_>>().join(", ")
-        ));
+        lines.push(String::new());
+        lines.push("Intercepted files are available at:".to_string());
+        let mut files: Vec<(&String, &String)> = manifest.files.iter().collect();
+        files.sort_by_key(|(k, _)| *k);
+        for (name, path) in files {
+            lines.push(format!("- `{}` → `{}`", name, path));
+        }
     }
 
     lines.push(String::new());
-    lines.push("IMPORTANT: Never hardcode secrets. Never echo secrets. Never write secrets to files.".to_string());
-    lines.push("Use `nanosb-secret read <KEY>` every time you need a value.".to_string());
+    lines.push("IMPORTANT: Never hardcode secrets. Never echo secret values. Always read from env vars.".to_string());
 
     lines.join("\n")
 }
 
-/// Write secrets protocol instructions to the appropriate agent config file inside the VM.
-#[allow(dead_code)]
+/// Write secrets access instructions to the appropriate agent config file inside the VM.
 async fn write_secrets_bootstrap(
     sandbox: &mut sandbox::Sandbox,
     agent_type: &str,

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -454,7 +454,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     panel.loading_message = Some(message);
                 }
             }
-            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount } => {
+            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active } => {
                 // Get SSH info before storing sandbox
                 let ssh_info = {
                     let sb = sandbox.lock().await;
@@ -475,6 +475,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         panel.ssh_host_port = Some(port);
                         panel.ssh_key_path = Some(key.clone());
                     }
+                    panel.secrets_active = secrets_active;
                 }
 
                 let is_auto_mode = app.panels.get(panel_idx)
@@ -492,6 +493,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
                         let is_resumed = panel.is_resumed;
                         let model = panel.model.clone();
+                        let panel_secrets_active = panel.secrets_active;
                         let tx = tx.clone();
                         tokio::spawn(async move {
                             spawn_gateway_exec(
@@ -499,6 +501,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                 workdir.as_deref(), permissions,
                                 prompt.as_deref(), is_resumed,
                                 model.as_deref(), panel_idx, tx,
+                                panel_secrets_active,
                             ).await;
                         });
                     }
@@ -524,6 +527,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
                         let is_resumed = panel.is_resumed;
                         let model = panel.model.clone();
+                        let panel_secrets_active = panel.secrets_active;
                         let ssh_host = "127.0.0.1".to_string();
                         let tx = tx.clone();
                         tokio::spawn(async move {
@@ -540,7 +544,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                     &agent_name, &env, workdir.as_deref(),
                                     permissions, false, prompt.as_deref(),
                                     is_resumed, model.as_deref(), panel_idx, tx.clone(),
-                                    false,
+                                    panel_secrets_active,
                                 ).await {
                                     Ok(handle) => {
                                         let _ = tx.send(AppEvent::SshConnected { panel_idx, handle });
@@ -1008,6 +1012,7 @@ async fn spawn_gateway_exec(
     model: Option<&str>,
     panel_idx: usize,
     tx: mpsc::UnboundedSender<AppEvent>,
+    secrets_active: bool,
 ) {
     let agent_cmd = super::terminal::agent_cli_command(
         agent_name, permissions, true, is_resumed, model,
@@ -1024,7 +1029,21 @@ async fn spawn_gateway_exec(
     };
 
     // Build environment map — panel env + agent-specific vars.
-    let mut exec_env = env.clone();
+    // When secrets were injected via the encrypted pipeline, skip secret-like
+    // env vars (API keys, tokens) so they are not also sent as plaintext.
+    let secret_suffixes = ["_KEY", "_TOKEN", "_SECRET", "_PASSWORD", "_CREDENTIAL"];
+    let mut exec_env: HashMap<String, String> = env
+        .iter()
+        .filter(|(k, _)| {
+            if secrets_active {
+                let upper = k.to_uppercase();
+                !secret_suffixes.iter().any(|s| upper.ends_with(s))
+            } else {
+                true
+            }
+        })
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
     exec_env.extend(super::terminal::agent_env_vars(
         agent_name, permissions, true, model, prompt,
     ));
@@ -1999,6 +2018,7 @@ async fn handle_command(
                     let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
                     let is_resumed = panel.is_resumed;
                     let model = panel.model.clone();
+                    let panel_secrets_active = panel.secrets_active;
                     // Use 127.0.0.1 on all platforms — on Windows, portproxy
                     // rules route localhost to the guest IP via HCN NAT.
                     let ssh_host = "127.0.0.1".to_string();
@@ -2009,7 +2029,7 @@ async fn handle_command(
                             &agent_name, &env, workdir.as_deref(),
                             permissions, auto_mode, prompt.as_deref(),
                             is_resumed, model.as_deref(), panel_idx, tx.clone(),
-                            false,
+                            panel_secrets_active,
                         ).await {
                             Ok(handle) => {
                                 let _ = tx.send(AppEvent::SshConnected { panel_idx, handle });
@@ -4046,6 +4066,7 @@ fn add_agent(
                             sandbox: sb,
                             short_id,
                             project_mount,
+                            secrets_active: false,
                         });
                     }
                     Err(e) => {
@@ -4143,10 +4164,23 @@ fn add_agent_from_config(
     app.show_welcome = false;
     app.focus_panel_input();
 
+    // Capture config_dir (directory containing sandbox.yml) before the async move.
+    // Use the project path from config, falling back to CWD.
+    let config_dir = config
+        .sandbox
+        .project
+        .as_ref()
+        .map(|p| p.path.clone())
+        .or_else(|| app.project_path.clone())
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    // Capture the agent type string for secrets bootstrap.
+    let agent_type_str = agent_type.clone();
+
     let tx = tx.clone();
     let image_manager = app.image_manager.clone();
     tokio::spawn(async move {
         let resolved_agent = config.resolved_agent.clone();
+        let secrets_cfg = config.secrets.clone();
         let _ = tx.send(AppEvent::SandboxCreating {
             panel_idx,
             message: "Pulling image...".into(),
@@ -4174,6 +4208,29 @@ fn add_agent_from_config(
                         if let Some(resolved) = &resolved_agent {
                             let _ = sandbox.bootstrap_agent(resolved).await;
                         }
+
+                        // Secrets injection (lifecycle — works for both auto and interactive)
+                        let clone_path = sandbox
+                            .project_mount()
+                            .and_then(|pm| pm.worktree_base.clone());
+                        let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
+                            match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
+                                Ok(manifest) => {
+                                    if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
+                                        let bootstrap = secrets_bootstrap_content(&manifest);
+                                        let _ = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await;
+                                    }
+                                    true
+                                }
+                                Err(e) => {
+                                    tracing::error!("Secrets injection failed: {}", e);
+                                    false
+                                }
+                            }
+                        } else {
+                            false
+                        };
+
                         let project_mount = sandbox.take_project_mount();
                         let sb = Arc::new(Mutex::new(sandbox));
                         let _ = tx.send(AppEvent::SandboxReady {
@@ -4181,6 +4238,7 @@ fn add_agent_from_config(
                             sandbox: sb,
                             short_id,
                             project_mount,
+                            secrets_active,
                         });
                     }
                     Err(e) => {
@@ -4320,11 +4378,21 @@ fn resume_session(
         app.show_welcome = false;
         app.focus_panel_input();
 
+        // Capture config_dir and agent_type_str for secrets injection before async move.
+        let config_dir = config
+            .sandbox
+            .project
+            .as_ref()
+            .map(|p| p.path.clone())
+            .unwrap_or_else(|| session.project_path.clone());
+        let agent_type_str = agent_type.clone();
+
         // Spawn sandbox creation in background.
         let tx = tx.clone();
         let image_manager = app.image_manager.clone();
         tokio::spawn(async move {
             let resolved_agent = config.resolved_agent.clone();
+            let secrets_cfg = config.secrets.clone();
             let _ = tx.send(AppEvent::SandboxCreating {
                 panel_idx,
                 message: "Pulling image...".into(),
@@ -4352,6 +4420,29 @@ fn resume_session(
                             if let Some(resolved) = &resolved_agent {
                                 let _ = sandbox.bootstrap_agent(resolved).await;
                             }
+
+                            // Secrets injection (lifecycle — works for both auto and interactive)
+                            let clone_path = sandbox
+                                .project_mount()
+                                .and_then(|pm| pm.worktree_base.clone());
+                            let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
+                                match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
+                                    Ok(manifest) => {
+                                        if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
+                                            let bootstrap = secrets_bootstrap_content(&manifest);
+                                            let _ = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await;
+                                        }
+                                        true
+                                    }
+                                    Err(e) => {
+                                        tracing::error!("Secrets injection failed: {}", e);
+                                        false
+                                    }
+                                }
+                            } else {
+                                false
+                            };
+
                             let project_mount = sandbox.take_project_mount();
                             let sb = Arc::new(Mutex::new(sandbox));
                             let _ = tx.send(AppEvent::SandboxReady {
@@ -4359,6 +4450,7 @@ fn resume_session(
                                 sandbox: sb,
                                 short_id,
                                 project_mount,
+                                secrets_active,
                             });
                         }
                         Err(e) => {

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -5196,6 +5196,84 @@ fn inject_secrets(
     Ok(manifest)
 }
 
+/// Generate secrets protocol instructions for agent config files.
+#[allow(dead_code)]
+fn secrets_bootstrap_content(manifest: &runtime::SecretManifest) -> String {
+    let mut lines = Vec::new();
+    lines.push("## Secrets Access Protocol".to_string());
+    lines.push(String::new());
+    lines.push("All secrets and credentials in this workspace are managed by nanosb-secret.".to_string());
+    lines.push("Do NOT read .env files, environment variables, or any credential files directly.".to_string());
+    lines.push(String::new());
+    lines.push("Available commands:".to_string());
+    lines.push("- `nanosb-secret list` — list available secret key names".to_string());
+    lines.push("- `nanosb-secret read <KEY>` — read a secret value".to_string());
+    lines.push("- `nanosb-secret file <FILENAME>` — read an intercepted file's contents".to_string());
+    lines.push("- `nanosb-secret export <KEY> <PATH>` — write secret to a file for tools that need a file path".to_string());
+    lines.push(String::new());
+
+    if !manifest.secrets.is_empty() {
+        let mut keys: Vec<&String> = manifest.secrets.keys().collect();
+        keys.sort();
+        lines.push(format!(
+            "Available secret keys: {}",
+            keys.iter().map(|k| format!("`{}`", k)).collect::<Vec<_>>().join(", ")
+        ));
+    }
+
+    if !manifest.files.is_empty() {
+        let mut files: Vec<&String> = manifest.files.keys().collect();
+        files.sort();
+        lines.push(format!(
+            "Intercepted files: {}",
+            files.iter().map(|f| format!("`{}`", f)).collect::<Vec<_>>().join(", ")
+        ));
+    }
+
+    lines.push(String::new());
+    lines.push("IMPORTANT: Never hardcode secrets. Never echo secrets. Never write secrets to files.".to_string());
+    lines.push("Use `nanosb-secret read <KEY>` every time you need a value.".to_string());
+
+    lines.join("\n")
+}
+
+/// Write secrets protocol instructions to the appropriate agent config file inside the VM.
+#[allow(dead_code)]
+async fn write_secrets_bootstrap(
+    sandbox: &mut sandbox::Sandbox,
+    agent_type: &str,
+    content: &str,
+) -> anyhow::Result<()> {
+    let file_path = match agent_type {
+        "claude" => "/workspace/CLAUDE.md",
+        "codex" => "/workspace/.codexrc",
+        "goose" => "/workspace/.goose/instructions.md",
+        _ => return Ok(()), // Unknown agent, skip
+    };
+
+    // Read existing content (if any) and prepend
+    let existing = sandbox
+        .exec_with_options("cat", &[file_path], Default::default())
+        .await
+        .map(|r| r.stdout)
+        .unwrap_or_default();
+
+    let new_content = format!("{}\n\n{}", content, existing);
+    let escaped = new_content.replace('\'', "'\\''");
+
+    sandbox
+        .exec_with_options(
+            "sh",
+            &["-c", &format!("mkdir -p $(dirname '{}') && printf '%s' '{}' > '{}'", file_path, escaped, file_path)],
+            Default::default(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to write {}: {}", file_path, e))?;
+
+    tracing::info!("Wrote secrets bootstrap to {}", file_path);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -454,7 +454,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     panel.loading_message = Some(message);
                 }
             }
-            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active, secrets_env } => {
+            AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount, secrets_active } => {
                 // Get SSH info before storing sandbox
                 let ssh_info = {
                     let sb = sandbox.lock().await;
@@ -476,7 +476,6 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         panel.ssh_key_path = Some(key.clone());
                     }
                     panel.secrets_active = secrets_active;
-                    panel.secrets_env = secrets_env;
                 }
 
                 let is_auto_mode = app.panels.get(panel_idx)
@@ -523,7 +522,6 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         let agent_name = panel.agent_name.clone();
                         // Gateway merges secrets automatically — just pass panel env.
                         let env = panel.env.clone();
-                        let secrets_env = panel.secrets_env.clone();
                         let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                         let permissions = panel.permissions;
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
@@ -542,7 +540,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                 match super::terminal::connect_ssh(
                                     ssh_host.clone(), ssh_port, key_path.clone(),
                                     pty_cols, pty_rows,
-                                    &agent_name, &env, &secrets_env, workdir.as_deref(),
+                                    &agent_name, &env, workdir.as_deref(),
                                     permissions, false, prompt.as_deref(),
                                     is_resumed, model.as_deref(), panel_idx, tx.clone(),
                                 ).await {
@@ -2002,7 +2000,6 @@ async fn handle_command(
                     let agent_name = panel.agent_name.clone();
                     // Gateway merges secrets automatically — just pass panel env.
                     let env = panel.env.clone();
-                    let secrets_env = panel.secrets_env.clone();
                     let workdir = panel.project_mount.as_ref().map(|_| "/workspace".to_string());
                     let permissions = panel.permissions;
                     let auto_mode = panel.auto_mode;
@@ -2016,7 +2013,7 @@ async fn handle_command(
                     tokio::spawn(async move {
                         match super::terminal::connect_ssh(
                             ssh_host, ssh_port, key_path, pty_cols, pty_rows,
-                            &agent_name, &env, &secrets_env, workdir.as_deref(),
+                            &agent_name, &env, workdir.as_deref(),
                             permissions, auto_mode, prompt.as_deref(),
                             is_resumed, model.as_deref(), panel_idx, tx.clone(),
                         ).await {
@@ -4056,7 +4053,6 @@ fn add_agent(
                             short_id,
                             project_mount,
                             secrets_active: false,
-                            secrets_env: HashMap::new(),
                         });
                     }
                     Err(e) => {
@@ -4203,24 +4199,24 @@ fn add_agent_from_config(
                         let clone_path = sandbox
                             .project_mount()
                             .and_then(|pm| pm.worktree_base.clone());
-                        let (secrets_active, secrets_env) = if let Some(ref secrets_cfg) = secrets_cfg {
+                        let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
                             match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                Ok((manifest, secrets_env)) => {
+                                Ok(manifest) => {
                                     if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
                                         let bootstrap = secrets_bootstrap_content(&manifest);
                                         if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
                                             tracing::warn!("Failed to write secrets bootstrap: {}", e);
                                         }
                                     }
-                                    (true, secrets_env)
+                                    true
                                 }
                                 Err(e) => {
                                     tracing::error!("Secrets injection failed: {}", e);
-                                    (false, HashMap::new())
+                                    false
                                 }
                             }
                         } else {
-                            (false, HashMap::new())
+                            false
                         };
 
                         let project_mount = sandbox.take_project_mount();
@@ -4231,7 +4227,6 @@ fn add_agent_from_config(
                             short_id,
                             project_mount,
                             secrets_active,
-                            secrets_env,
                         });
                     }
                     Err(e) => {
@@ -4418,24 +4413,24 @@ fn resume_session(
                             let clone_path = sandbox
                                 .project_mount()
                                 .and_then(|pm| pm.worktree_base.clone());
-                            let (secrets_active, secrets_env) = if let Some(ref secrets_cfg) = secrets_cfg {
+                            let secrets_active = if let Some(ref secrets_cfg) = secrets_cfg {
                                 match inject_secrets(&mut sandbox, secrets_cfg, &config_dir, &clone_path) {
-                                    Ok((manifest, secrets_env)) => {
+                                    Ok(manifest) => {
                                         if !manifest.secrets.is_empty() || !manifest.files.is_empty() {
                                             let bootstrap = secrets_bootstrap_content(&manifest);
                                             if let Err(e) = write_secrets_bootstrap(&mut sandbox, &agent_type_str, &bootstrap).await {
                                                 tracing::warn!("Failed to write secrets bootstrap: {}", e);
                                             }
                                         }
-                                        (true, secrets_env)
+                                        true
                                     }
                                     Err(e) => {
                                         tracing::error!("Secrets injection failed: {}", e);
-                                        (false, HashMap::new())
+                                        false
                                     }
                                 }
                             } else {
-                                (false, HashMap::new())
+                                false
                             };
 
                             let project_mount = sandbox.take_project_mount();
@@ -4446,7 +4441,6 @@ fn resume_session(
                                 short_id,
                                 project_mount,
                                 secrets_active,
-                                secrets_env,
                             });
                         }
                         Err(e) => {
@@ -5246,15 +5240,15 @@ fn handle_agent_info(app: &mut App, name: &str) {
 
 /// Collect, encrypt, and send secrets to the sandbox gateway.
 ///
-/// Returns the manifest describing what was injected and the raw secret
-/// key/value map for SSH channel.set_env() injection. The gateway holds the
-/// decrypted secrets in memory and merges them into every exec call automatically.
+/// Returns the manifest describing what was injected. The gateway holds the
+/// decrypted secrets in memory and merges them into every exec call and SSH
+/// session automatically.
 fn inject_secrets(
     sandbox: &mut sandbox::Sandbox,
     secrets_config: &sandbox::SecretSource,
     config_dir: &std::path::Path,
     clone_path: &Option<std::path::PathBuf>,
-) -> anyhow::Result<(runtime::SecretManifest, HashMap<String, String>)> {
+) -> anyhow::Result<runtime::SecretManifest> {
     // 1. Collect secrets from SOPS file and host env
     let mut payload = crate::collect_secrets(secrets_config, config_dir)?;
 
@@ -5275,14 +5269,11 @@ fn inject_secrets(
     }
 
     if payload.is_empty() {
-        return Ok((runtime::SecretManifest {
+        return Ok(runtime::SecretManifest {
             secrets: std::collections::HashMap::new(),
             files: std::collections::HashMap::new(),
-        }, HashMap::new()));
+        });
     }
-
-    // Clone secret values before encrypting, for SSH channel.set_env() injection.
-    let secrets_env = payload.secrets.clone();
 
     // 3. Get gateway public key
     // Deref through AgentSandbox -> SandboxInner -> runtime::Sandbox (git dep)
@@ -5310,7 +5301,7 @@ fn inject_secrets(
     let manifest = runtime_sb.send_secrets(&encrypted_json)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    Ok((manifest, secrets_env))
+    Ok(manifest)
 }
 
 /// Generate secrets access instructions for agent config files.

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -1075,30 +1075,34 @@ async fn spawn_gateway_exec(
         let tx_data = tx.clone();
         let chunk_counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
         let chunk_counter_cb = chunk_counter.clone();
-        sb.exec_stream_with_options(
-            "sh",
-            &["-c", &shell_cmd],
-            exec_opts,
-            move |chunk| {
-                // Gateway SSE events don't include trailing newlines, but the
-                // headless NDJSON parser splits on \n. Append newline to each
-                // chunk (same as `nanosb exec` in main.rs).
-                let n = chunk_counter_cb.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                if n == 1 || n % 20 == 0 {
-                    let preview: String = chunk.data.chars().take(200).collect();
-                    tracing::info!(
-                        "[spawn_gateway_exec] chunk #{} (stream={:?}): {}",
-                        n, chunk.stream, preview
-                    );
-                }
-                let mut data = chunk.data.into_bytes();
-                data.push(b'\n');
-                let _ = tx_data.send(AppEvent::TerminalData {
-                    panel_idx,
-                    data,
-                });
-            },
-        ).await
+        let gw_result = match sb.gateway() {
+            Ok(gw) => gw.exec_stream_with_options(
+                "sh",
+                &["-c", &shell_cmd],
+                exec_opts,
+                move |chunk| {
+                    // Gateway SSE events don't include trailing newlines, but the
+                    // headless NDJSON parser splits on \n. Append newline to each
+                    // chunk (same as `nanosb exec` in main.rs).
+                    let n = chunk_counter_cb.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    if n == 1 || n % 20 == 0 {
+                        let preview: String = chunk.data.chars().take(200).collect();
+                        tracing::info!(
+                            "[spawn_gateway_exec] chunk #{} (stream={:?}): {}",
+                            n, chunk.stream, preview
+                        );
+                    }
+                    let mut data = chunk.data.into_bytes();
+                    data.push(b'\n');
+                    let _ = tx_data.send(AppEvent::TerminalData {
+                        panel_idx,
+                        data,
+                    });
+                },
+            ).await,
+            Err(e) => Err(e),
+        };
+        gw_result
     };
 
     match exec_result {
@@ -4664,7 +4668,8 @@ async fn handle_mcp_add(app: &mut App, name: &str, command: &str, args: &[String
 
     let body = serde_json::json!({ "name": name, "config": config }).to_string();
     let sb = sandbox.lock().await;
-    match sb.gateway_http_post("/api/v1/mcp/servers", &body) {
+    let result = sb.gateway().and_then(|gw| gw.http_post("/api/v1/mcp/servers", &body));
+    match result {
         Ok((status, _)) if status < 400 => {
             panel.chat_history.push(ChatMessage {
                 role: MessageRole::System,
@@ -4706,7 +4711,8 @@ async fn handle_mcp_remove(app: &mut App, name: &str) {
 
     let path = format!("/api/v1/mcp/servers/{}", name);
     let sb = sandbox.lock().await;
-    match sb.gateway_http_delete(&path) {
+    let result = sb.gateway().and_then(|gw| gw.http_delete(&path));
+    match result {
         Ok((status, _)) if status < 400 => {
             panel.chat_history.push(ChatMessage {
                 role: MessageRole::System,
@@ -4748,7 +4754,8 @@ async fn handle_mcp_enable(app: &mut App, name: &str) {
 
     let path = format!("/api/v1/mcp/servers/{}/enable", name);
     let sb = sandbox.lock().await;
-    match sb.gateway_http_post(&path, "{}") {
+    let result = sb.gateway().and_then(|gw| gw.http_post(&path, "{}"));
+    match result {
         Ok((status, _)) if status < 400 => {
             panel.chat_history.push(ChatMessage {
                 role: MessageRole::System,
@@ -4790,7 +4797,8 @@ async fn handle_mcp_disable(app: &mut App, name: &str) {
 
     let path = format!("/api/v1/mcp/servers/{}/disable", name);
     let sb = sandbox.lock().await;
-    match sb.gateway_http_post(&path, "{}") {
+    let result = sb.gateway().and_then(|gw| gw.http_post(&path, "{}"));
+    match result {
         Ok((status, _)) if status < 400 => {
             panel.chat_history.push(ChatMessage {
                 role: MessageRole::System,
@@ -5328,7 +5336,7 @@ fn send_encrypted_env(
     secrets_config: Option<&sandbox::SecretSource>,
     config_dir: &std::path::Path,
     clone_path: &Option<std::path::PathBuf>,
-) -> anyhow::Result<runtime::SecretManifest> {
+) -> anyhow::Result<sandbox::SecretManifest> {
     let mut payload = sandbox::secrets::payload::SecretPayload::new();
 
     // 1. If secrets: config exists, collect from SOPS file and host env keys
@@ -5356,22 +5364,23 @@ fn send_encrypted_env(
     }
 
     // 2. Add ALL config.env vars to the payload
-    let runtime_sb = &mut ***sandbox;
-    for (k, v) in &runtime_sb.config().env {
+    for (k, v) in &(***sandbox).config().env {
         if !payload.secrets.contains_key(k) {
             payload.add_secret(k.clone(), v.clone());
         }
     }
 
     if payload.secrets.is_empty() && payload.intercepted_files.is_empty() {
-        return Ok(runtime::SecretManifest {
+        return Ok(sandbox::SecretManifest {
             secrets: std::collections::HashMap::new(),
             files: std::collections::HashMap::new(),
         });
     }
 
-    // 3. Encrypt using the RUNTIME's crypto (same crate as decrypt — no version mismatch)
-    let pubkey_b64 = runtime_sb.secrets_pubkey()
+    // 3. Encrypt using the gateway's crypto (same crate as decrypt — no version mismatch)
+    let pubkey_b64 = (**sandbox).gateway()
+        .map_err(|e| anyhow::anyhow!("Gateway not available: {}", e))?
+        .secrets_pubkey()
         .ok_or_else(|| anyhow::anyhow!("Gateway secrets pubkey not available"))?;
 
     let pubkey_bytes: [u8; 32] = base64::engine::general_purpose::STANDARD
@@ -5383,20 +5392,22 @@ fn send_encrypted_env(
     let plaintext = payload.to_json_bytes()
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    let encrypted = runtime::encrypt_payload(&plaintext, &pubkey_bytes)
+    let encrypted = sandbox::encrypt_payload(&plaintext, &pubkey_bytes)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let encrypted_json = serde_json::to_string(&encrypted)?;
 
-    // 4. Send encrypted payload → runtime decrypts → stores in secrets_store + POSTs to gateway
-    let manifest = runtime_sb.send_secrets(&encrypted_json)
+    // 4. Send encrypted payload → gateway decrypts → stores in secrets_store
+    let manifest = (**sandbox).gateway_mut()
+        .map_err(|e| anyhow::anyhow!("Gateway not available: {}", e))?
+        .send_secrets(&encrypted_json)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     Ok(manifest)
 }
 
 /// Generate secrets access instructions for agent config files.
-fn secrets_bootstrap_content(manifest: &runtime::SecretManifest) -> String {
+fn secrets_bootstrap_content(manifest: &sandbox::SecretManifest) -> String {
     let mut lines = Vec::new();
     lines.push("## Secrets Access".to_string());
     lines.push(String::new());
@@ -5443,23 +5454,29 @@ async fn write_secrets_bootstrap(
     };
 
     // Read existing content (if any) and prepend
-    let existing = sandbox
-        .exec_with_options("cat", &[file_path], Default::default())
-        .await
-        .map(|r| r.stdout)
-        .unwrap_or_default();
+    let existing = match (**sandbox).gateway() {
+        Ok(gw) => gw.exec_with_options("cat", &[file_path], Default::default())
+            .await
+            .map(|r| r.stdout)
+            .unwrap_or_default(),
+        Err(_) => String::new(),
+    };
 
     let new_content = format!("{}\n\n{}", content, existing);
     let escaped = new_content.replace('\'', "'\\''");
 
-    sandbox
-        .exec_with_options(
-            "sh",
-            &["-c", &format!("mkdir -p $(dirname '{}') && printf '%s' '{}' > '{}'", file_path, escaped, file_path)],
-            Default::default(),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to write {}: {}", file_path, e))?;
+    let write_cmd = format!(
+        "mkdir -p $(dirname '{}') && printf '%s' '{}' > '{}'",
+        file_path, escaped, file_path
+    );
+    match (**sandbox).gateway() {
+        Ok(gw) => {
+            gw.exec_with_options("sh", &["-c", &write_cmd], Default::default())
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to write {}: {}", file_path, e))?;
+        }
+        Err(e) => return Err(anyhow::anyhow!("Gateway not available: {}", e)),
+    }
 
     tracing::info!("Wrote secrets bootstrap to {}", file_path);
     Ok(())

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -178,7 +178,6 @@ pub async fn connect_ssh(
     rows: u16,
     agent_name: &str,
     env: &HashMap<String, String>,
-    secrets_env: &HashMap<String, String>,
     workdir: Option<&str>,
     permissions: sandbox::Permissions,
     auto_mode: bool,
@@ -218,10 +217,6 @@ pub async fn connect_ssh(
         env_parts.push(format!("cd '{}'", dir));
     }
     for (key, val) in env {
-        env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
-    }
-    // Secrets from encrypted pipeline (delivered over encrypted SSH channel, VM is ephemeral)
-    for (key, val) in secrets_env {
         env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
     }
     // Agent-specific env vars (Goose mode, prompt, etc.)

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -210,18 +210,13 @@ pub async fn connect_ssh(
         anyhow::bail!("SSH public key authentication failed");
     }
 
-    // Build the initialization commands (cd + env vars + agent CLI launch)
+    // Build the initialization commands (cd + agent CLI launch).
+    // All env vars (secrets + config + agent-specific) are injected by the
+    // gateway's embedded SSH server via cmd.Env — no shell export needed.
     let mut env_parts: Vec<String> = Vec::new();
 
     if let Some(dir) = workdir {
         env_parts.push(format!("cd '{}'", dir));
-    }
-    for (key, val) in env {
-        env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
-    }
-    // Agent-specific env vars (Goose mode, prompt, etc.)
-    for (key, val) in agent_env_vars(agent_name, permissions, auto_mode, model, prompt) {
-        env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
     }
 
     let agent_cmd = agent_cli_command(agent_name, permissions, auto_mode, is_resumed, model);

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -186,6 +186,7 @@ pub async fn connect_ssh(
     model: Option<&str>,
     panel_idx: usize,
     tx: mpsc::UnboundedSender<AppEvent>,
+    secrets_active: bool,
 ) -> Result<SshTerminalHandle, anyhow::Error> {
     // Load the private key
     let key_data = tokio::fs::read_to_string(&key_path).await?;
@@ -216,7 +217,14 @@ pub async fn connect_ssh(
     if let Some(dir) = workdir {
         env_parts.push(format!("cd '{}'", dir));
     }
+    let secret_suffixes = ["_KEY", "_TOKEN", "_SECRET", "_PASSWORD", "_CREDENTIAL"];
     for (key, val) in env {
+        let upper = key.to_uppercase();
+        let is_secret = secret_suffixes.iter().any(|s| upper.ends_with(s));
+        if is_secret && secrets_active {
+            // Skip — this secret was injected via the encrypted pipeline
+            continue;
+        }
         env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
     }
     // Agent-specific env vars (Goose mode, prompt, etc.)

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -220,6 +220,10 @@ pub async fn connect_ssh(
     for (key, val) in env {
         env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
     }
+    // Secrets from encrypted pipeline (delivered over encrypted SSH channel, VM is ephemeral)
+    for (key, val) in secrets_env {
+        env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
+    }
     // Agent-specific env vars (Goose mode, prompt, etc.)
     for (key, val) in agent_env_vars(agent_name, permissions, auto_mode, model, prompt) {
         env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
@@ -228,14 +232,6 @@ pub async fn connect_ssh(
     let agent_cmd = agent_cli_command(agent_name, permissions, auto_mode, is_resumed, model);
 
     let channel = session.channel_open_session().await?;
-
-    // Inject secrets via SSH protocol env vars (no export, no files).
-    // sshd must have AcceptEnv configured (done during secrets injection).
-    for (key, val) in secrets_env {
-        if let Err(e) = channel.set_env(false, key.as_str(), val.as_str()).await {
-            tracing::warn!("Failed to set SSH env var '{}': {}", key, e);
-        }
-    }
 
     if auto_mode {
         // Headless: use channel.exec() to run a single compound command directly.

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -178,6 +178,7 @@ pub async fn connect_ssh(
     rows: u16,
     agent_name: &str,
     env: &HashMap<String, String>,
+    secrets_env: &HashMap<String, String>,
     workdir: Option<&str>,
     permissions: sandbox::Permissions,
     auto_mode: bool,
@@ -227,6 +228,14 @@ pub async fn connect_ssh(
     let agent_cmd = agent_cli_command(agent_name, permissions, auto_mode, is_resumed, model);
 
     let channel = session.channel_open_session().await?;
+
+    // Inject secrets via SSH protocol env vars (no export, no files).
+    // sshd must have AcceptEnv configured (done during secrets injection).
+    for (key, val) in secrets_env {
+        if let Err(e) = channel.set_env(false, key.as_str(), val.as_str()).await {
+            tracing::warn!("Failed to set SSH env var '{}': {}", key, e);
+        }
+    }
 
     if auto_mode {
         // Headless: use channel.exec() to run a single compound command directly.

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -186,7 +186,6 @@ pub async fn connect_ssh(
     model: Option<&str>,
     panel_idx: usize,
     tx: mpsc::UnboundedSender<AppEvent>,
-    secrets_active: bool,
 ) -> Result<SshTerminalHandle, anyhow::Error> {
     // Load the private key
     let key_data = tokio::fs::read_to_string(&key_path).await?;
@@ -217,14 +216,7 @@ pub async fn connect_ssh(
     if let Some(dir) = workdir {
         env_parts.push(format!("cd '{}'", dir));
     }
-    let secret_suffixes = ["_KEY", "_TOKEN", "_SECRET", "_PASSWORD", "_CREDENTIAL"];
     for (key, val) in env {
-        let upper = key.to_uppercase();
-        let is_secret = secret_suffixes.iter().any(|s| upper.ends_with(s));
-        if is_secret && secrets_active {
-            // Skip — this secret was injected via the encrypted pipeline
-            continue;
-        }
         env_parts.push(format!("export {}='{}'", key, val.replace('\'', "'\\''")));
     }
     // Agent-specific env vars (Goose mode, prompt, etc.)


### PR DESCRIPTION
## Summary
- Add encrypted secrets pipeline: collect secrets from SOPS files and host env, encrypt via X25519+AES-256-GCM, send to gateway for injection into sandbox process env vars
- Route auto-detected API keys through encrypted pipeline, skip shell export for secret-like env vars
- Refactor secrets flow: gateway SSH handles injection, remove client-side secret storage
- Fix Windows installer: restructure prerequisites (Hyper-V, WHPX, WSL, VirtualMachinePlatform) with consistent `Enable-WindowsOptionalFeature` pattern and single reboot prompt
- Fix logging: add `sandbox` crate to tracing filter so sandbox warn/error logs are captured

## Related Issues
Closes #43

## Test plan
- [x] Local macOS build and test
- [x] Windows VM testing — installer prerequisites, sandbox launch
- [x] GitHub Actions CI builds (Linux, macOS, Windows) via v0.2.0-rc19
- [ ] End-to-end secrets injection test with real API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)