### PR TITLE
feat(tui): runtime-only startup env with selective /add imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ nanosb --project /path/to/project
 
 # Override resources
 nanosb --cpus 4 --memory 8192 --timeout 1200
+
+# Provide runtime env pool for this TUI run
+nanosb --env OPENAI_API_KEY=... --env-file .env.local
+```
+
+Notes:
+- In TUI mode, startup env is runtime-only (not persisted to sessions).
+- `sandbox.yml` env values take precedence over startup env for matching keys.
+- Local `.env` is auto-loaded only when no `sandbox.yml` is active.
+- `/add` does not import startup env automatically; select keys explicitly with `--use-env`.
+
+```bash
+# Add panel and import selected startup env keys
+/add claude --use-env OPENAI_API_KEY --use-env GITHUB_TOKEN
 ```
 
 ### CLI Commands

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,37 +425,26 @@ mod cli {
                         .map_err(|e| anyhow::anyhow!("{}", e))?
                 };
 
-                // Auto-load .env from project directory (lowest priority).
-                // Check --project flag first, then CWD if it's a git repo.
-                let auto_env_dir = cli
-                    .project
-                    .as_ref()
-                    .map(std::path::PathBuf::from)
-                    .or_else(|| std::env::current_dir().ok());
-                if let Some(ref dir) = auto_env_dir {
-                    let env_path = dir.join(".env");
-                    if env_path.exists() {
-                        let project_env =
-                            sandbox::config::file::load_env_file(&env_path.to_string_lossy(), dir)
-                                .map_err(|e| {
-                                    error!("Failed to load env file {:?}: {}", env_path, e);
-                                    anyhow::anyhow!("{}", e)
-                                })?;
-                        for (_, config) in sandbox_configs.iter_mut() {
-                            for (k, v) in &project_env {
-                                // Only set if not already defined by sandbox.yml
-                                config
-                                    .sandbox
-                                    .env
-                                    .entry(k.clone())
-                                    .or_insert_with(|| v.clone());
-                            }
+                // Build runtime-only env pool for this invocation.
+                // Source order: optional auto .env (no-config mode only), then --env-file, then --env.
+                let mut runtime_env: Vec<(String, String)> = Vec::new();
+
+                // Auto-load .env only when no sandbox config is active.
+                if sandbox_configs.is_empty() {
+                    if let Ok(cwd) = std::env::current_dir() {
+                        let env_path = cwd.join(".env");
+                        if env_path.exists() {
+                            let auto_env_files = vec![env_path.to_string_lossy().to_string()];
+                            let auto_env = parse_env_vars(&[], &auto_env_files)?;
+                            runtime_env.extend(auto_env);
                         }
                     }
                 }
 
                 // Parse --env and --env-file into key-value pairs.
+                // These are runtime-only for TUI mode and never persisted.
                 let cli_env = parse_env_vars(&cli.env, &cli.env_file)?;
+                runtime_env.extend(cli_env.iter().cloned());
 
                 // Parse --permissions flag.
                 let cli_permissions = cli
@@ -475,8 +464,13 @@ mod cli {
                     cli.memory,
                     cli.timeout,
                     cli_permissions,
-                    &cli_env,
+                    &[],
                 );
+
+                let mut runtime_env_pool = std::collections::HashMap::new();
+                for (k, v) in runtime_env {
+                    runtime_env_pool.insert(k, v);
+                }
 
                 // Filter to a single sandbox if --sandbox is specified.
                 let sandbox_configs = if let Some(ref name) = cli.sandbox {
@@ -508,7 +502,13 @@ mod cli {
                     nanosb_cli::tui::run::SessionStartMode::Fresh
                 };
 
-                nanosb_cli::tui::run::run_tui(project_path, sandbox_configs, session_start).await
+                nanosb_cli::tui::run::run_tui(
+                    project_path,
+                    sandbox_configs,
+                    session_start,
+                    runtime_env_pool,
+                )
+                .await
             }
             Some(Commands::Pull { image }) => cmd_pull(&image, cli.format, cli.verbose).await,
             Some(Commands::Images) => cmd_images(cli.format).await,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -285,6 +285,9 @@ pub struct AgentPanel {
     /// Per-panel environment variables (e.g., API keys).
     /// Merged with host env when sending messages (panel env takes priority).
     pub env: HashMap<String, String>,
+    /// Env keys that came from startup runtime env pool for this invocation.
+    /// These keys are runtime-only and must not be persisted into sessions.
+    pub runtime_env_keys: HashSet<String>,
     /// Current operating mode of the panel.
     pub mode: PanelMode,
     /// Last rendered input width (set by renderer, used by key handler for cursor movement).
@@ -363,6 +366,7 @@ impl AgentPanel {
             input: TextInput::new(),
             sandbox_id_short: String::new(),
             env: HashMap::new(),
+            runtime_env_keys: HashSet::new(),
             mode: PanelMode::Loading,
             last_input_width: 40,
             terminal: None,
@@ -468,6 +472,9 @@ pub struct App {
     /// Pending confirmation prompt: message + list of panel indices to reconnect on 'y'.
     /// Shown as a system popup; 'y' triggers reconnect, 'n'/Esc dismisses.
     pub pending_reconnect: Option<Vec<usize>>,
+    /// Startup runtime env pool (`--env`, `--env-file`, optional auto `.env` in no-config mode).
+    /// This is in-memory only for the current process.
+    pub runtime_env_pool: HashMap<String, String>,
 }
 
 impl Default for App {
@@ -515,6 +522,7 @@ impl App {
             destroy_on_quit: false,
             command_history: CommandHistory::new(),
             pending_reconnect: None,
+            runtime_env_pool: HashMap::new(),
         }
     }
 

--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -37,6 +37,8 @@ pub enum Command {
         prompt: Option<String>,
         /// Optional model identifier (e.g., "claude-sonnet-4-5-20250929").
         model: Option<String>,
+        /// Runtime env keys to import from nanosb startup env pool.
+        use_env: Vec<String>,
     },
     /// Switch focus to a specific panel index.
     Focus {
@@ -248,12 +250,13 @@ fn parse_add(parts: &[&str]) -> ParseResult {
         Some(a) => *a,
         None => {
             return ParseResult::Err(format!(
-                "Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--image <image>] [--project <path>] [--branch <name>] [--name <name>]\n\
+                "Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n\
                  Supported agents: {}\n\
                  Example: /add claude\n\
                  With tag: /add claude --tag rc11\n\
                  With model: /add claude --model claude-sonnet-4-5-20250929\n\
-                 Headless: /add claude --auto-mode -p \"list files\"",
+                 Headless: /add claude --auto-mode -p \"list files\"\n\
+                 With runtime env: /add claude --use-env OPENAI_API_KEY",
                 SUPPORTED_AGENTS.join(", "),
             ));
         }
@@ -267,6 +270,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
     let mut auto_mode = false;
     let mut prompt = None;
     let mut model = None;
+    let mut use_env: Vec<String> = Vec::new();
     let mut i = 2;
 
     while i < parts.len() {
@@ -352,6 +356,21 @@ fn parse_add(parts: &[&str]) -> ParseResult {
                     ),
                 }
             }
+            "--use-env" => {
+                match parts.get(i + 1) {
+                    Some(v) => {
+                        use_env.push(v.to_string());
+                        i += 2;
+                    }
+                    None => {
+                        return ParseResult::Err(
+                            "--use-env requires a key name\n\
+                             Usage: /add <agent> --use-env <KEY>"
+                                .to_string(),
+                        )
+                    }
+                }
+            }
             "--auto-mode" => {
                 auto_mode = true;
                 i += 1;
@@ -375,7 +394,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
             other => {
                 return ParseResult::Err(format!(
                     "Unknown option: {}\n\
-                     Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--image <image>] [--project <path>] [--branch <name>] [--name <name>]",
+                     Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...",
                     other,
                 ));
             }
@@ -411,6 +430,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
         auto_mode,
         prompt,
         model,
+        use_env,
     })
 }
 
@@ -722,6 +742,7 @@ mod tests {
                 auto_mode: false,
                 prompt: None,
                 model: None,
+                use_env: vec![],
             })
         );
     }
@@ -740,6 +761,7 @@ mod tests {
                 auto_mode: false,
                 prompt: None,
                 model: None,
+                use_env: vec![],
             })
         );
     }
@@ -838,6 +860,7 @@ mod tests {
                 auto_mode: false,
                 prompt: None,
                 model: None,
+                use_env: vec![],
             })
         );
     }
@@ -1023,6 +1046,7 @@ mod tests {
                 auto_mode: false,
                 prompt: None,
                 model: None,
+                use_env: vec![],
             })
         );
     }
@@ -1041,6 +1065,7 @@ mod tests {
                 auto_mode: false,
                 prompt: None,
                 model: None,
+                use_env: vec![],
             })
         );
     }
@@ -1078,6 +1103,7 @@ mod tests {
                 auto_mode: true,
                 prompt: Some("list files".to_string()),
                 model: None,
+                use_env: vec![],
             })
         );
     }
@@ -1097,6 +1123,7 @@ mod tests {
                 auto_mode: true,
                 prompt: Some("analyse project".to_string()),
                 model: None,
+                use_env: vec![],
             })
         );
     }
@@ -1113,6 +1140,31 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_add_with_use_env_keys() {
+        assert_eq!(
+            parse_command_verbose("/add claude --use-env OPENAI_API_KEY --use-env GITHUB_TOKEN"),
+            ParseResult::Ok(Command::AddAgent {
+                agent: "claude".to_string(),
+                image: None,
+                tag: None,
+                project: None,
+                branch: None,
+                name: None,
+                auto_mode: false,
+                prompt: None,
+                model: None,
+                use_env: vec!["OPENAI_API_KEY".to_string(), "GITHUB_TOKEN".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_add_use_env_missing_value() {
+        let result = parse_command_verbose("/add claude --use-env");
+        assert!(matches!(result, ParseResult::Err(msg) if msg.contains("--use-env requires a key name")));
+    }
+
+    #[test]
     fn test_parse_add_prompt_flag() {
         assert_eq!(
             parse_command_verbose("/add codex --auto-mode --prompt fix the bug"),
@@ -1126,6 +1178,7 @@ mod tests {
                 auto_mode: true,
                 prompt: Some("fix the bug".to_string()),
                 model: None,
+                use_env: vec![],
             })
         );
     }
@@ -1352,6 +1405,7 @@ mod tests {
                 auto_mode: false,
                 prompt: None,
                 model: Some("claude-sonnet-4-5-20250929".to_string()),
+                use_env: vec![],
             })
         );
     }
@@ -1381,6 +1435,7 @@ mod tests {
                 auto_mode: true,
                 prompt: Some("do stuff".to_string()),
                 model: Some("claude-opus-4-20250514".to_string()),
+                use_env: vec![],
             })
         );
     }

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -206,6 +206,7 @@ pub async fn run_tui(
     project_path: Option<std::path::PathBuf>,
     sandbox_configs: Vec<(String, sandbox::AgentSandboxConfig)>,
     session_start: SessionStartMode,
+    runtime_env_pool: HashMap<String, String>,
 ) -> anyhow::Result<()> {
     // Check if we're running in a real terminal.
     if !io::stdout().is_terminal() {
@@ -358,6 +359,7 @@ pub async fn run_tui(
     // Create app state.
     let mut app = App::new();
     app.project_path = project_path;
+    app.runtime_env_pool = runtime_env_pool;
 
     // Create shared image manager so all sandboxes coordinate pulls
     // (prevents concurrent downloads of the same image layers).
@@ -1882,7 +1884,7 @@ async fn handle_command(
                 role: MessageRole::System,
                 content: concat!(
                     "Available commands:\n",
-                    "  /add <agent> [--image <img>] [--project <path>] [--branch <name>] [--name <name>]\n",
+                    "  /add <agent> [--image <img>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n",
                     "                                Add a new agent panel\n",
                     "  /sandboxes                    Toggle sandbox sidebar\n",
                     "  /focus <n>                    Focus panel n (0-indexed)\n",
@@ -2009,8 +2011,8 @@ async fn handle_command(
         Command::McpToggle => {
             app.show_mcp_sidebar = !app.show_mcp_sidebar;
         }
-        Command::AddAgent { agent, image, tag, project, branch, name, auto_mode, prompt, model } => {
-            add_agent(app, &agent, image.as_deref(), tag.as_deref(), project.as_deref(), branch.as_deref(), name.as_deref(), auto_mode, prompt.as_deref(), model.as_deref(), tx);
+        Command::AddAgent { agent, image, tag, project, branch, name, auto_mode, prompt, model, use_env } => {
+            add_agent(app, &agent, image.as_deref(), tag.as_deref(), project.as_deref(), branch.as_deref(), name.as_deref(), auto_mode, prompt.as_deref(), model.as_deref(), &use_env, tx);
         }
         Command::Env { assignment } => {
             handle_env(app, assignment);
@@ -3991,6 +3993,7 @@ fn add_agent(
     auto_mode: bool,
     prompt: Option<&str>,
     model: Option<&str>,
+    use_env_keys: &[String],
     tx: &mpsc::UnboundedSender<AppEvent>,
 ) {
     // Build image reference. --tag overrides the default "latest" tag
@@ -4027,6 +4030,30 @@ fn add_agent(
             panel.env.insert("GOOSE_PROVIDER".to_string(), "anthropic".to_string());
         } else if panel.env.contains_key("OPENAI_API_KEY") {
             panel.env.insert("GOOSE_PROVIDER".to_string(), "openai".to_string());
+        }
+    }
+
+    // Selectively import startup runtime env keys into this panel.
+    if !use_env_keys.is_empty() {
+        let mut missing: Vec<String> = Vec::new();
+        for key in use_env_keys {
+            if let Some(value) = app.runtime_env_pool.get(key) {
+                panel.env.insert(key.clone(), value.clone());
+                panel.runtime_env_keys.insert(key.clone());
+            } else {
+                missing.push(key.clone());
+            }
+        }
+
+        if !missing.is_empty() {
+            app.set_system_message(ChatMessage {
+                role: MessageRole::System,
+                content: format!(
+                    "Cannot add panel: runtime env key(s) not found: {}",
+                    missing.join(", ")
+                ),
+            });
+            return;
         }
     }
 
@@ -4202,6 +4229,14 @@ fn add_agent_from_config(
         panel.env.insert(k.clone(), v.clone());
     }
 
+    // Import startup runtime env pool as fallback only (config keys win).
+    for (key, value) in &app.runtime_env_pool {
+        if !panel.env.contains_key(key) {
+            panel.env.insert(key.clone(), value.clone());
+            panel.runtime_env_keys.insert(key.clone());
+        }
+    }
+
     // Auto-detect API keys from host environment (if not already in config env).
     for (api_key, _) in &required_api_keys(&agent_type) {
         if !panel.env.contains_key(*api_key) {
@@ -4231,6 +4266,7 @@ fn add_agent_from_config(
 
     // Store the runtime config for session persistence.
     panel.original_config = Some(config.clone());
+    let panel_env: HashMap<String, String> = panel.env.clone();
 
     app.panels.push(panel);
     let panel_idx = app.panels.len() - 1;
@@ -4286,6 +4322,12 @@ fn add_agent_from_config(
                     Ok(()) => {
                         if let Some(resolved) = &resolved_agent {
                             let _ = sandbox.bootstrap_agent(resolved).await;
+                        }
+
+                        // Insert panel env vars (config env + runtime-selected/startup fallback)
+                        // into runtime config.env so they're delivered via gateway POST.
+                        for (key, val) in &panel_env {
+                            (**sandbox).config_mut().env.insert(key.clone(), val.clone());
                         }
 
                         // Merge agent-specific env vars (GOOSE_MODE, NANOSB_PROMPT, etc.)
@@ -4521,13 +4563,6 @@ fn resume_session(
         // Normalize the image in case the session was saved with a bare name.
         config.sandbox.image = sandbox::normalize_image(&config.sandbox.image);
 
-        // Re-populate env vars from host environment (secrets are not stored in session).
-        for key in &sp.env_keys {
-            if let Ok(val) = std::env::var(key) {
-                config.sandbox.env.insert(key.clone(), val);
-            }
-        }
-
         // Set up the agent panel.
         let agent_type = detect_agent_type_from_image(&config.sandbox.image)
             .unwrap_or_else(|| sp.agent_name.clone());
@@ -4548,6 +4583,17 @@ fn resume_session(
         // Copy env vars from config to panel.
         for (k, v) in &config.sandbox.env {
             panel.env.insert(k.clone(), v.clone());
+        }
+
+        // Re-populate saved env keys from host env first, then startup runtime pool.
+        // Values are runtime-only and are not copied back into persisted config.
+        for key in &sp.env_keys {
+            if let Ok(val) = std::env::var(key) {
+                panel.env.insert(key.clone(), val);
+            } else if let Some(val) = app.runtime_env_pool.get(key) {
+                panel.env.insert(key.clone(), val.clone());
+                panel.runtime_env_keys.insert(key.clone());
+            }
         }
 
         // Auto-detect API keys from host environment.
@@ -4619,6 +4665,8 @@ fn resume_session(
             panel.selected_agent_session_id.as_deref(),
         );
 
+        let panel_env: HashMap<String, String> = panel.env.clone();
+
         app.panels.push(panel);
         let panel_idx = app.panels.len() - 1;
         app.focused_panel = panel_idx;
@@ -4671,6 +4719,12 @@ fn resume_session(
                         Ok(()) => {
                             if let Some(resolved) = &resolved_agent {
                                 let _ = sandbox.bootstrap_agent(resolved).await;
+                            }
+
+                            // Insert panel env vars (config + resumed runtime values)
+                            // into runtime config.env so they're delivered via gateway POST.
+                            for (key, val) in &panel_env {
+                                (**sandbox).config_mut().env.insert(key.clone(), val.clone());
                             }
 
                             // Merge agent-specific env vars (GOOSE_MODE, NANOSB_PROMPT, etc.)
@@ -4772,6 +4826,7 @@ fn handle_env(app: &mut App, assignment: Option<(String, String)>) {
         }
         Some((key, value)) => {
             if let Some(panel) = app.focused_panel_mut() {
+                panel.runtime_env_keys.remove(&key);
                 panel.env.insert(key.clone(), value);
                 panel.chat_history.push(ChatMessage {
                     role: MessageRole::System,
@@ -5054,7 +5109,12 @@ fn build_session_from_app(
                 .map(|pm| pm.created_branches.clone())
                 .unwrap_or_default();
 
-            let env_keys: Vec<String> = panel.env.keys().cloned().collect();
+            let env_keys: Vec<String> = panel
+                .env
+                .keys()
+                .filter(|k| !panel.runtime_env_keys.contains(*k))
+                .cloned()
+                .collect();
 
             let selected_agent_session_id = panel
                 .selected_agent_session_id


### PR DESCRIPTION
## Summary
- make TUI startup env (`--env`/`--env-file`) runtime-only and stop persisting those values into session snapshots
- enforce config-first precedence for env keys and auto-load local `.env` only in no-config mode
- add selective runtime env import for new panels via `/add ... --use-env <KEY>` and document the behavior

## Testing
- `cargo test -p nanosb-cli tui::commands -- --nocapture`
- `cargo check -p nanosb-cli`
- `cargo build --release -p nanosb-cli`

## Linked issue
- Closes #56