### PR TITLE
fix(windows): stabilize auth callback forwarding and terminal paste flow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ mod cli {
     use std::time::Duration;
     use tabled::{Table, Tabled};
     use tokio::sync::Mutex;
-    use tracing::{error, info, warn};
+    use tracing::{error, warn};
 
     /// Output format for commands
     #[derive(Debug, Clone, Copy, ValueEnum, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,10 +352,10 @@ mod cli {
                     .ok()
                     .filter(|v| !v.is_empty())
                     .unwrap_or_else(|| default_level.to_string());
-                let file_filter = format!(
-                    "runtime={lvl},nanosb_cli={lvl},nanosb={lvl},sandbox={lvl}",
-                    lvl = file_level
-                );
+                // Use a global default level so that ALL crates (including
+                // nanosb_cli) are captured.  Previous per-crate filters
+                // silently missed the TUI module on Windows.
+                let file_filter = file_level.clone();
                 let file_layer = fmt::layer()
                     .with_writer(file_writer)
                     .with_ansi(false)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -315,6 +315,8 @@ pub struct AgentPanel {
     pub sync_override: Option<bool>,
     /// SSH host port for port forwarding (stored from SandboxReady).
     pub ssh_host_port: Option<u16>,
+    /// SSH host/IP used to reach the guest (e.g. 127.0.0.1 or HCN guest IP).
+    pub ssh_host: Option<String>,
     /// SSH private key path for port forwarding (stored from SandboxReady).
     pub ssh_key_path: Option<PathBuf>,
     /// Guest ports with active SSH local-port-forwards (`ssh -L`).
@@ -379,6 +381,7 @@ impl AgentPanel {
             base_commit: None,
             sync_override: None,
             ssh_host_port: None,
+            ssh_host: None,
             ssh_key_path: None,
             forwarded_ports: HashSet::new(),
             port_forward_children: Vec::new(),
@@ -475,6 +478,10 @@ pub struct App {
     /// Startup runtime env pool (`--env`, `--env-file`, optional auto `.env` in no-config mode).
     /// This is in-memory only for the current process.
     pub runtime_env_pool: HashMap<String, String>,
+    /// Windows-only key suppression window after Ctrl+V to ignore
+    /// terminal-emulator key injection and avoid duplicate/interrupted paste.
+    #[cfg(target_os = "windows")]
+    pub paste_suppress_until: Option<std::time::Instant>,
 }
 
 impl Default for App {
@@ -523,6 +530,8 @@ impl App {
             command_history: CommandHistory::new(),
             pending_reconnect: None,
             runtime_env_pool: HashMap::new(),
+            #[cfg(target_os = "windows")]
+            paste_suppress_until: None,
         }
     }
 

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,8 +1,11 @@
 //! Event system for the TUI.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use ratatui::crossterm::event::{self, Event as CrosstermEvent};
+#[cfg(target_os = "windows")]
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tokio::sync::{mpsc, Mutex};
 
 use sandbox::Sandbox;
@@ -96,30 +99,96 @@ pub enum AppEvent {
 /// Spawn a background task that reads terminal events and forwards them to the channel.
 pub fn spawn_terminal_event_reader(tx: mpsc::UnboundedSender<AppEvent>) {
     tokio::spawn(async move {
+        #[cfg(target_os = "windows")]
+        let mut consecutive_read_errors: u32 = 0;
+
         loop {
             // Blocking read wrapped in spawn_blocking to avoid blocking the async runtime.
             //
-            // On Windows, crossterm's event::read() does a save→modify→read→restore
-            // cycle on the console input mode. The "restore" undoes our custom flags
-            // (ENABLE_MOUSE_INPUT, ~QUICK_EDIT, ~PROCESSED_INPUT) every time. We
-            // re-apply them inside the spawn_blocking closure, right after read()
-            // returns, so the corrected mode is what crossterm saves on the NEXT call.
-            let evt = tokio::task::spawn_blocking(|| {
-                let result = event::read();
+            // On Windows we use poll()+read() instead of a bare blocking read().
+            // crossterm's event::read() performs a save→modify→read→restore cycle
+            // on the console input mode; the "restore" briefly re-enables
+            // QUICK_EDIT_MODE which can freeze the TUI if the user clicks during
+            // that window.  By polling with a short timeout we keep the window
+            // small and can re-apply our console mode fix frequently.
+            //
+            // We also drain *all* available events in one spawn_blocking call so
+            // that rapid-fire key events (Windows pastes individual characters
+            // when bracketed paste is unsupported) are batched together.
+            let events = tokio::task::spawn_blocking(|| {
+                let mut batch: Vec<CrosstermEvent> = Vec::new();
+
+                // Wait for the first event (up to 100ms on Windows, blocking on others).
+                #[cfg(target_os = "windows")]
+                let has_first = match event::poll(Duration::from_millis(100)) {
+                    Ok(true) => match event::read() {
+                        Ok(evt) => { batch.push(evt); true }
+                        Err(_) => false,
+                    },
+                    Ok(false) => false, // timeout, no event
+                    Err(_) => false,
+                };
+                #[cfg(not(target_os = "windows"))]
+                let has_first = match event::read() {
+                    Ok(evt) => { batch.push(evt); true }
+                    Err(_) => false,
+                };
+
+                // Drain any immediately-available follow-up events (non-blocking).
+                // This batches rapid-fire key events from Windows paste.
+                if has_first {
+                    while let Ok(true) = event::poll(Duration::ZERO) {
+                        match event::read() {
+                            Ok(evt) => batch.push(evt),
+                            Err(_) => break,
+                        }
+                    }
+                }
+
                 #[cfg(target_os = "windows")]
                 super::run::fix_windows_console_mode();
-                result
+
+                (has_first, batch)
             })
             .await;
 
-            match evt {
-                Ok(Ok(crossterm_event)) => {
-                    if tx.send(AppEvent::Terminal(crossterm_event)).is_err() {
-                        // Receiver dropped; stop reading events.
-                        break;
+            match events {
+                Ok((true, batch)) => {
+                    #[cfg(target_os = "windows")]
+                    {
+                        consecutive_read_errors = 0;
+                    }
+
+                    // On Windows, coalesce sequential printable-char Press
+                    // events into synthetic Paste events so injected clipboard
+                    // text is forwarded in bulk through bracketed paste.
+                    #[cfg(target_os = "windows")]
+                    let batch = coalesce_char_events(batch);
+
+                    for evt in batch {
+                        if tx.send(AppEvent::Terminal(evt)).is_err() {
+                            return; // receiver dropped
+                        }
                     }
                 }
+                Ok((false, _)) => {
+                    // poll() timeout (Windows) — not an error, loop again.
+                    #[cfg(target_os = "windows")]
+                    continue;
+                    #[cfg(not(target_os = "windows"))]
+                    break;
+                }
                 _ => {
+                    #[cfg(target_os = "windows")]
+                    {
+                        consecutive_read_errors = consecutive_read_errors.saturating_add(1);
+                        super::run::fix_windows_console_mode();
+                        if consecutive_read_errors <= 50 {
+                            tokio::time::sleep(Duration::from_millis(20)).await;
+                            continue;
+                        }
+                    }
+
                     // Error reading event or task panicked; stop.
                     break;
                 }
@@ -127,3 +196,59 @@ pub fn spawn_terminal_event_reader(tx: mpsc::UnboundedSender<AppEvent>) {
         }
     });
 }
+
+#[cfg(target_os = "windows")]
+fn coalesce_char_events(events: Vec<CrosstermEvent>) -> Vec<CrosstermEvent> {
+    use ratatui::crossterm::event::KeyEventKind;
+
+    if events.len() <= 3 {
+        return events;
+    }
+
+    let mut result: Vec<CrosstermEvent> = Vec::with_capacity(events.len());
+    let mut char_buf = String::new();
+
+    for evt in events {
+        match &evt {
+            CrosstermEvent::Key(key)
+                if key.kind == KeyEventKind::Press
+                    && key.modifiers.is_empty()
+                    && matches!(key.code, KeyCode::Char(_)) =>
+            {
+                if let KeyCode::Char(c) = key.code {
+                    char_buf.push(c);
+                }
+            }
+            _ => {
+                if !char_buf.is_empty() {
+                    if char_buf.len() >= 2 {
+                        result.push(CrosstermEvent::Paste(std::mem::take(&mut char_buf)));
+                    } else {
+                        let c = char_buf.chars().next().unwrap();
+                        char_buf.clear();
+                        result.push(CrosstermEvent::Key(KeyEvent::new(
+                            KeyCode::Char(c),
+                            KeyModifiers::NONE,
+                        )));
+                    }
+                }
+                result.push(evt);
+            }
+        }
+    }
+
+    if !char_buf.is_empty() {
+        if char_buf.len() >= 2 {
+            result.push(CrosstermEvent::Paste(char_buf));
+        } else {
+            let c = char_buf.chars().next().unwrap();
+            result.push(CrosstermEvent::Key(KeyEvent::new(
+                KeyCode::Char(c),
+                KeyModifiers::NONE,
+            )));
+        }
+    }
+
+    result
+}
+

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -32,6 +32,11 @@ use super::commands::{self, Command};
 use super::event::{spawn_terminal_event_reader, AppEvent};
 use super::renderer;
 
+#[cfg(target_os = "windows")]
+const WINDOWS_PASTE_SUPPRESS_INITIAL_MS: u64 = 450;
+#[cfg(target_os = "windows")]
+const WINDOWS_PASTE_SUPPRESS_SILENCE_MS: u64 = 120;
+
 /// Cross-platform stderr redirection helpers.
 ///
 /// On Unix, native C libraries (libkrun, gvproxy) write to stderr via fprintf()
@@ -436,11 +441,41 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
     terminal.draw(|frame| renderer::render(frame, &mut app))?;
 
     // Main event loop.
+    //
+    // Windows-only: the SSH data reader can flood the channel with
+    // TerminalData events during heavy agent output.  We limit how many
+    // we handle per iteration and yield so keyboard events get through.
+    #[cfg(target_os = "windows")]
+    let mut terminal_data_budget: u32 = 64;
     while let Some(event) = rx.recv().await {
+        #[cfg(target_os = "windows")]
+        if !matches!(&event, AppEvent::TerminalData { .. }) {
+            terminal_data_budget = 64;
+        }
         match event {
             AppEvent::Terminal(crossterm_event) => {
                 match crossterm_event {
                     CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => {
+                        #[cfg(target_os = "windows")]
+                        {
+                            let now = std::time::Instant::now();
+                            if let Some(until) = app.paste_suppress_until {
+                                if now < until {
+                                    app.paste_suppress_until = Some(
+                                        now + Duration::from_millis(WINDOWS_PASTE_SUPPRESS_SILENCE_MS),
+                                    );
+                                    tracing::debug!(
+                                        key_code = ?key.code,
+                                        modifiers = ?key.modifiers,
+                                        suppress_silence_ms = WINDOWS_PASTE_SUPPRESS_SILENCE_MS,
+                                        "Suppressed key event during adaptive Ctrl+V window"
+                                    );
+                                    continue;
+                                }
+                                app.paste_suppress_until = None;
+                            }
+                        }
+
                         // Only handle Press events — on Windows, crossterm fires
                         // both Press and Release for each keystroke.
 
@@ -481,6 +516,31 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         handle_mouse_event(&mut app, mouse);
                     }
                     CrosstermEvent::Paste(text) => {
+                        #[cfg(target_os = "windows")]
+                        {
+                            let now = std::time::Instant::now();
+                            if let Some(until) = app.paste_suppress_until {
+                                if now < until {
+                                    app.paste_suppress_until = Some(
+                                        now + Duration::from_millis(WINDOWS_PASTE_SUPPRESS_SILENCE_MS),
+                                    );
+                                    tracing::debug!(
+                                        text_len = text.len(),
+                                        focused_panel = app.focused_panel,
+                                        suppress_silence_ms = WINDOWS_PASTE_SUPPRESS_SILENCE_MS,
+                                        "Suppressed duplicate Paste event during adaptive Ctrl+V window"
+                                    );
+                                    continue;
+                                }
+                                app.paste_suppress_until = None;
+                            }
+                        }
+
+                        tracing::info!(
+                            text_len = text.len(),
+                            focused_panel = app.focused_panel,
+                            "Received terminal paste event"
+                        );
                         handle_paste_event(&mut app, text, &tx);
                     }
                     CrosstermEvent::Resize(_cols, _rows) => {
@@ -505,9 +565,9 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
             }
             AppEvent::SandboxReady { panel_idx, sandbox, short_id, project_mount } => {
                 // Get SSH info before storing sandbox
-                let ssh_info = {
+                let (ssh_info, ssh_host_override) = {
                     let sb = sandbox.lock().await;
-                    sb.ssh_port().zip(sb.ssh_key_path())
+                    (sb.ssh_port().zip(sb.ssh_key_path()), sb.ssh_host())
                 };
 
                 if let Some(panel) = app.panels.get_mut(panel_idx) {
@@ -522,6 +582,9 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                     // Store SSH info for later port forwarding (ssh -L).
                     if let Some((port, ref key)) = ssh_info {
                         panel.ssh_host_port = Some(port);
+                        panel.ssh_host = Some(
+                            ssh_host_override.clone().unwrap_or_else(|| "127.0.0.1".to_string()),
+                        );
                         panel.ssh_key_path = Some(key.clone());
                     }
                 }
@@ -532,7 +595,7 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
 
                 if is_auto_mode {
                     // Auto-mode: use gateway exec (same as `nanosb exec`).
-                    // No SSH needed — runs command via HvSocket/HTTP gateway.
+                    // No SSH needed — runs command via the gateway transport.
                     if let Some(panel) = app.panels.get(panel_idx) {
                         let agent_name = panel.agent_name.clone();
                         // Gateway merges secrets automatically — just pass panel env.
@@ -577,11 +640,11 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         let is_resumed = panel.is_resumed;
                         let selected_agent_session_id = panel.selected_agent_session_id.clone();
                         let model = panel.model.clone();
-                        let ssh_host = "127.0.0.1".to_string();
+                        let ssh_host = ssh_host_override.clone().unwrap_or_else(|| "127.0.0.1".to_string());
                         let tx = tx.clone();
                         tokio::spawn(async move {
-                            // Retry SSH connection — on Windows the HvSocket SSH
-                            // proxy chain takes time to be ready after VM boot.
+                            // Retry SSH connection — on Windows the network path can
+                            // take time to be ready after VM boot.
                             let max_attempts = 10;
                             let mut last_err = String::new();
                             for attempt in 1..=max_attempts {
@@ -624,9 +687,18 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
             }
             AppEvent::SshConnected { panel_idx, handle } => {
                 if let Some(panel) = app.panels.get_mut(panel_idx) {
-                    let (cols, rows) = panel.last_terminal_size;
-                    panel.terminal = Some(super::terminal::SshTerminal::new(cols, rows));
-                    panel.terminal_handle = Some(handle);
+                    let was_reconnecting = panel.reconnecting;
+                    if was_reconnecting && panel.terminal.is_some() {
+                        // Reconnect: keep the existing terminal screen intact
+                        // so the user doesn't see any flicker. Only attach
+                        // the new SSH handle.
+                        panel.terminal_handle = Some(handle);
+                    } else {
+                        // Fresh connection: create new terminal.
+                        let (cols, rows) = panel.last_terminal_size;
+                        panel.terminal = Some(super::terminal::SshTerminal::new(cols, rows));
+                        panel.terminal_handle = Some(handle);
+                    }
                     panel.mode = if panel.auto_mode {
                         PanelMode::Headless
                     } else {
@@ -652,6 +724,31 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         // Still feed vt100 for /terminal fallback + URL extraction.
                         if let Some(ref mut term) = panel.terminal {
                             term.process_bytes(&data);
+
+                            let urls =
+                                super::terminal::extract_urls_from_screen(term.screen());
+                            let now = std::time::Instant::now();
+                            for url in urls {
+                                if !super::terminal::is_auth_url(&url) {
+                                    continue;
+                                }
+                                if !url.contains('?') && !super::terminal::is_device_code_url(&url) {
+                                    continue;
+                                }
+                                let key = super::terminal::url_dedup_key(&url);
+                                if panel.opened_urls.contains(&key) {
+                                    continue;
+                                }
+                                panel.pending_urls
+                                    .entry(key)
+                                    .and_modify(|(existing_url, ts)| {
+                                        if url.len() > existing_url.len() {
+                                            *existing_url = url.clone();
+                                            *ts = now;
+                                        }
+                                    })
+                                    .or_insert((url, now));
+                            }
                         }
                     } else if let Some(ref mut term) = panel.terminal {
                         term.process_bytes(&data);
@@ -695,6 +792,22 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                 .or_insert((url, now));
                         }
                     }
+                }
+
+                // Windows-only: prevent SSH data flood from starving
+                // keyboard/tick events during heavy agent output.
+                #[cfg(target_os = "windows")]
+                {
+                    terminal_data_budget = terminal_data_budget.saturating_sub(1);
+                    if terminal_data_budget == 0 {
+                        terminal_data_budget = 64;
+                        // Render so user sees progress during heavy output.
+                        terminal.draw(|frame| renderer::render(frame, &mut app))?;
+                        // Yield to let keyboard events be processed.
+                        tokio::task::yield_now().await;
+                    }
+                    // Skip the per-event render — we batch renders above.
+                    continue;
                 }
             }
             AppEvent::SshDisconnected { panel_idx, error } => {
@@ -785,6 +898,14 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         .collect();
                     for key in ready {
                         if let Some((url, _)) = panel.pending_urls.remove(&key) {
+                            tracing::debug!(
+                                panel = %panel.agent_name,
+                                dedup_key = %key,
+                                url = %url,
+                                ssh_host = ?panel.ssh_host,
+                                ssh_port = ?panel.ssh_host_port,
+                                "Auth URL debounce elapsed; preparing open/forward"
+                            );
                             // Forward OAuth callback port via SSH local-port-forward.
                             // The agent's callback server listens on 127.0.0.1 inside
                             // the VM. gvproxy expose_port sends traffic to the VM's
@@ -801,32 +922,94 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                                             "{}:127.0.0.1:{}",
                                             port, port
                                         );
-                                        let ssh_dest = "root@127.0.0.1".to_string();
-                                        if let Ok(child) =
-                                            std::process::Command::new("ssh")
-                                                .args([
-                                                    "-L", &fwd,
-                                                    "-p", &ssh_port.to_string(),
-                                                    "-i",
-                                                    &key_path.to_string_lossy().as_ref(),
-                                                    "-o", "StrictHostKeyChecking=no",
-                                                    "-o", if cfg!(unix) { "UserKnownHostsFile=/dev/null" } else { "UserKnownHostsFile=NUL" },
-                                                    "-o", "LogLevel=ERROR",
-                                                    "-N",
-                                                    &ssh_dest,
-                                                ])
-                                                .stdin(std::process::Stdio::null())
-                                                .stdout(std::process::Stdio::null())
-                                                .stderr(std::process::Stdio::null())
-                                                .spawn()
+                                        let ssh_host = panel
+                                            .ssh_host
+                                            .as_deref()
+                                            .unwrap_or("127.0.0.1");
+                                        let ssh_dest = format!("root@{}", ssh_host);
+                                        match std::process::Command::new("ssh")
+                                            .args([
+                                                "-L", &fwd,
+                                                "-p", &ssh_port.to_string(),
+                                                "-i",
+                                                &key_path.to_string_lossy().as_ref(),
+                                                "-o", "BatchMode=yes",
+                                                "-o", "ExitOnForwardFailure=yes",
+                                                "-o", "StrictHostKeyChecking=no",
+                                                "-o", if cfg!(unix) { "UserKnownHostsFile=/dev/null" } else { "UserKnownHostsFile=NUL" },
+                                                "-o", "LogLevel=ERROR",
+                                                "-N",
+                                                &ssh_dest,
+                                            ])
+                                            .stdin(std::process::Stdio::null())
+                                            .stdout(std::process::Stdio::null())
+                                            .stderr(std::process::Stdio::piped())
+                                            .spawn()
                                         {
-                                            panel.forwarded_ports.insert(port);
-                                            panel.port_forward_children.push(child);
+                                            Ok(mut child) => {
+                                                if let Some(stderr) = child.stderr.take() {
+                                                    let panel_name = panel.agent_name.clone();
+                                                    std::thread::spawn(move || {
+                                                        use std::io::BufRead;
+                                                        let reader = std::io::BufReader::new(stderr);
+                                                        for line in reader.lines() {
+                                                            match line {
+                                                                Ok(line) => tracing::debug!(
+                                                                    panel = %panel_name,
+                                                                    callback_port = port,
+                                                                    line = %line,
+                                                                    "OAuth callback SSH forward stderr"
+                                                                ),
+                                                                Err(e) => {
+                                                                    tracing::debug!(
+                                                                        panel = %panel_name,
+                                                                        callback_port = port,
+                                                                        error = %e,
+                                                                        "OAuth callback SSH forward stderr reader ended"
+                                                                    );
+                                                                    break;
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                }
+
+                                                tracing::debug!(
+                                                    panel = %panel.agent_name,
+                                                    callback_port = port,
+                                                    ssh_dest = %ssh_dest,
+                                                    ssh_port,
+                                                    "Started OAuth callback SSH port-forward"
+                                                );
+                                                panel.forwarded_ports.insert(port);
+                                                panel.port_forward_children.push(child);
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    panel = %panel.agent_name,
+                                                    callback_port = port,
+                                                    ssh_dest = %ssh_dest,
+                                                    ssh_port,
+                                                    error = %e,
+                                                    "Failed to start OAuth callback SSH port-forward"
+                                                );
+                                            }
                                         }
                                     }
                                 }
+                            } else {
+                                tracing::debug!(
+                                    panel = %panel.agent_name,
+                                    url = %url,
+                                    "Auth URL does not contain localhost redirect port; skipping callback forward"
+                                );
                             }
                             panel.opened_urls.insert(key);
+                            tracing::debug!(
+                                panel = %panel.agent_name,
+                                url = %url,
+                                "Opening auth URL in host browser"
+                            );
                             super::terminal::open_url_in_browser(&url);
                         }
                     }
@@ -1511,55 +1694,114 @@ async fn handle_key_event(
                     // If no image, forward the keystroke to the terminal.
                     // Note: Cmd+V on macOS is handled by the terminal emulator
                     // and arrives as CrosstermEvent::Paste, handled separately.
-                    KeyCode::Char('v') if key.modifiers.contains(KeyModifiers::CONTROL)
-                        || key.modifiers.contains(KeyModifiers::SUPER) => {
-                        if let Some((panel_idx, ssh_host, ssh_port, key_path)) = panel_ssh_info(app) {
-                            // Clone the write channel so the async task can forward
-                            // Ctrl+V to the terminal if no clipboard image is found.
-                            let write_tx = app.panels.get(app.focused_panel)
-                                .and_then(|p| p.terminal_handle.as_ref())
-                                .map(|h| h.write_tx.clone());
-                            let tx = tx.clone();
-                            tokio::spawn(async move {
-                                let result = tokio::task::spawn_blocking(
+                    KeyCode::Char(ch)
+                        if ((ch == 'v' || ch == 'V')
+                            && (key.modifiers.contains(KeyModifiers::CONTROL)
+                                || key.modifiers.contains(KeyModifiers::SUPER)))
+                            // Some Windows terminals emit Ctrl+V as SYN (0x16)
+                            // without reporting CONTROL in modifiers.
+                            || (cfg!(target_os = "windows") && ch == '\u{16}') => {
+                        #[cfg(target_os = "windows")]
+                        {
+                            // Windows terminal emulators can inject the clipboard
+                            // payload as raw key events after Ctrl+V. Ignore those
+                            // for a short window to prevent duplicate/interrupted paste.
+                            // While suppressed events keep arriving, we keep extending
+                            // the window until input goes quiet.
+                            app.paste_suppress_until = Some(
+                                std::time::Instant::now()
+                                    + Duration::from_millis(WINDOWS_PASTE_SUPPRESS_INITIAL_MS),
+                            );
+                        }
+
+                        let focused_panel = app.focused_panel;
+                        let panel_mode = app
+                            .panels
+                            .get(focused_panel)
+                            .map(|p| p.mode)
+                            .unwrap_or(PanelMode::Loading);
+                        tracing::info!(
+                            panel_idx = focused_panel,
+                            mode = ?panel_mode,
+                            key_char = ?ch,
+                            modifiers = ?key.modifiers,
+                            "Paste key detected (Ctrl/Cmd+V)"
+                        );
+
+                        // Clone the write channel so the async task can still
+                        // paste text even if SSH metadata is not ready yet.
+                        let write_tx = app.panels.get(app.focused_panel)
+                            .and_then(|p| p.terminal_handle.as_ref())
+                            .map(|h| h.write_tx.clone());
+                        let upload_info = panel_ssh_info(app);
+                        let tx = tx.clone();
+                        tokio::spawn(async move {
+                            tracing::debug!(
+                                has_upload_info = upload_info.is_some(),
+                                has_write_tx = write_tx.is_some(),
+                                "Handling Ctrl/Cmd+V paste"
+                            );
+
+                            // Fast path for Windows: paste text immediately.
+                            // Checking for clipboard image first can add noticeable
+                            // latency before any text appears in the terminal.
+                            let text_result = tokio::task::spawn_blocking(
+                                super::upload::read_clipboard_text,
+                            )
+                            .await;
+
+                            let text = match text_result {
+                                Ok(Ok(text)) => text,
+                                Ok(Err(e)) => {
+                                    tracing::debug!(error = %e, "Clipboard text read failed");
+                                    String::new()
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "Clipboard text task failed");
+                                    String::new()
+                                }
+                            };
+
+                            if !text.is_empty() {
+                                if let Some(ref wtx) = write_tx {
+                                    let sent = send_bracketed_paste(wtx, &text);
+                                    tracing::debug!(
+                                        text_len = text.len(),
+                                        sent,
+                                        "Forwarded clipboard text as bracketed paste"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        text_len = text.len(),
+                                        "Clipboard text available but terminal write channel missing"
+                                    );
+                                }
+                                return;
+                            }
+
+                            // Try clipboard image upload first when we have SSH
+                            // metadata for out-of-band upload.
+                            if let Some((panel_idx, ssh_host, ssh_port, key_path)) = upload_info {
+                                let image = tokio::task::spawn_blocking(
                                     super::upload::read_clipboard_image,
                                 )
                                 .await;
-                                match result {
-                                    Ok(Ok((png_bytes, filename))) => {
-                                        super::upload::spawn_bytes_upload(
-                                            ssh_host, ssh_port, key_path, png_bytes, filename,
-                                            panel_idx, tx,
-                                        );
-                                    }
-                                    Ok(Err(_)) | Err(_) => {
-                                        // No image in clipboard — try reading text
-                                        // from clipboard and pasting it (bracketed).
-                                        // On macOS Cmd+V arrives as CrosstermEvent::Paste
-                                        // with the text; on Windows Ctrl+V arrives as a
-                                        // key event so we read the clipboard ourselves.
-                                        let pasted = tokio::task::spawn_blocking(|| {
-                                            arboard::Clipboard::new()
-                                                .and_then(|mut cb| cb.get_text())
-                                                .ok()
-                                        }).await.ok().flatten();
-                                        if let Some(Some(text)) = Some(pasted) {
-                                            if let Some(ref wtx) = write_tx {
-                                                if !text.is_empty() {
-                                                    let mut buf = Vec::with_capacity(text.len() + 12);
-                                                    buf.extend_from_slice(b"\x1b[200~");
-                                                    buf.extend_from_slice(text.as_bytes());
-                                                    buf.extend_from_slice(b"\x1b[201~");
-                                                    let _ = wtx.send(buf);
-                                                }
-                                            }
-                                        } else if let Some(wtx) = write_tx {
-                                            let _ = wtx.send(vec![0x16]); // fallback: Ctrl+V
-                                        }
-                                    }
+                                if let Ok(Ok((png_bytes, filename))) = image {
+                                    tracing::debug!(
+                                        panel_idx,
+                                        filename = %filename,
+                                        bytes = png_bytes.len(),
+                                        "Clipboard image detected; starting upload"
+                                    );
+                                    super::upload::spawn_bytes_upload(
+                                        ssh_host, ssh_port, key_path, png_bytes, filename,
+                                        panel_idx, tx,
+                                    );
+                                    return;
                                 }
-                            });
-                        }
+                            }
+                            tracing::debug!("Clipboard paste produced empty text and no image");
+                        });
                         return;
                     }
                     // Scrollback: Shift+PageUp/PageDown to scroll terminal history.
@@ -2073,9 +2315,10 @@ async fn handle_command(
                     let is_resumed = panel.is_resumed;
                     let selected_agent_session_id = panel.selected_agent_session_id.clone();
                     let model = panel.model.clone();
-                    // Use 127.0.0.1 on all platforms — on Windows, portproxy
-                    // rules route localhost to the guest IP via HCN NAT.
-                    let ssh_host = "127.0.0.1".to_string();
+                    let ssh_host = panel
+                        .ssh_host
+                        .clone()
+                        .unwrap_or_else(|| "127.0.0.1".to_string());
                     let tx = tx.clone();
                     tokio::spawn(async move {
                         match super::terminal::connect_ssh(
@@ -2729,7 +2972,10 @@ fn panel_ssh_info(app: &App) -> Option<(usize, String, u16, std::path::PathBuf)>
     let panel = app.panels.get(idx)?;
     let port = panel.ssh_host_port?;
     let key = panel.ssh_key_path.clone()?;
-    let host = "127.0.0.1".to_string();
+    let host = panel
+        .ssh_host
+        .clone()
+        .unwrap_or_else(|| "127.0.0.1".to_string());
     Some((idx, host, port, key))
 }
 
@@ -2851,9 +3097,17 @@ fn handle_paste_event(
     text: String,
     tx: &mpsc::UnboundedSender<AppEvent>,
 ) {
+    tracing::info!(
+        text_len = text.len(),
+        focused_panel = app.focused_panel,
+        input_focus = ?app.input_focus,
+        "Processing paste event"
+    );
+
     // If focus is on the global input bar, insert the text there.
     if app.input_focus == InputFocus::Global {
         app.global_input.insert_str(&text);
+        tracing::debug!(text_len = text.len(), "Inserted paste into global input");
         return;
     }
 
@@ -2863,24 +3117,33 @@ fn handle_paste_event(
         if let Some((panel_idx, ssh_host, ssh_port, key_path)) = panel_ssh_info(app) {
             let tx = tx.clone();
             tokio::spawn(async move {
+                tracing::debug!(panel_idx, "Empty paste; checking clipboard image");
                 let result = tokio::task::spawn_blocking(
                     super::upload::read_clipboard_image,
                 )
                 .await;
                 match result {
                     Ok(Ok((png_bytes, filename))) => {
+                        tracing::debug!(
+                            panel_idx,
+                            filename = %filename,
+                            bytes = png_bytes.len(),
+                            "Empty paste resolved to clipboard image upload"
+                        );
                         super::upload::spawn_bytes_upload(
                             ssh_host, ssh_port, key_path, png_bytes, filename,
                             panel_idx, tx,
                         );
                     }
                     Ok(Err(e)) => {
+                        tracing::debug!(panel_idx, error = %e, "No clipboard image for empty paste");
                         let _ = tx.send(AppEvent::UploadFailed {
                             panel_idx,
                             error: e,
                         });
                     }
                     Err(e) => {
+                        tracing::warn!(panel_idx, error = %e, "Clipboard image task failed for empty paste");
                         let _ = tx.send(AppEvent::UploadFailed {
                             panel_idx,
                             error: format!("Clipboard task panicked: {}", e),
@@ -2888,6 +3151,8 @@ fn handle_paste_event(
                     }
                 }
             });
+        } else {
+            tracing::debug!("Empty paste ignored: no SSH panel info available");
         }
         return;
     }
@@ -2900,14 +3165,24 @@ fn handle_paste_event(
     if let Some(panel) = app.panels.get(app.focused_panel) {
         if panel.mode == PanelMode::Terminal {
             if let Some(ref handle) = panel.terminal_handle {
-                let mut buf = Vec::with_capacity(text.len() + 12);
-                buf.extend_from_slice(b"\x1b[200~");
-                buf.extend_from_slice(text.as_bytes());
-                buf.extend_from_slice(b"\x1b[201~");
-                let _ = handle.write_tx.send(buf);
+                let sent = send_bracketed_paste(&handle.write_tx, &text);
+                tracing::debug!(
+                    panel_idx = app.focused_panel,
+                    text_len = text.len(),
+                    sent,
+                    "Forwarded Crossterm paste to terminal"
+                );
             }
         }
     }
+}
+
+fn send_bracketed_paste(write_tx: &mpsc::UnboundedSender<Vec<u8>>, text: &str) -> bool {
+    let mut buf = Vec::with_capacity(text.len() + 12);
+    buf.extend_from_slice(b"\x1b[200~");
+    buf.extend_from_slice(text.as_bytes());
+    buf.extend_from_slice(b"\x1b[201~");
+    write_tx.send(buf).is_ok()
 }
 
 /// Handle a mouse event for panel-scoped text selection.

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -197,7 +197,45 @@ pub async fn connect_ssh(
     );
 
     // Connect
-    let config = russh::client::Config::default();
+    let mut config = russh::client::Config::default();
+
+    // Legacy Windows localhost SSH used an HvSocket-backed path that could
+    // stall. We still detect that case and use more conservative settings.
+    let is_localhost_ssh = ssh_host == "127.0.0.1" || ssh_host.eq_ignore_ascii_case("localhost");
+
+    let aggressive_stall_detection = cfg!(target_os = "windows") && is_localhost_ssh;
+    let read_timeout = if aggressive_stall_detection {
+        std::time::Duration::from_secs(30)
+    } else {
+        std::time::Duration::from_secs(3600)
+    };
+    tracing::info!(
+        panel_idx,
+        ssh_host = %ssh_host,
+        ssh_port,
+        is_localhost_ssh,
+        aggressive_stall_detection,
+        read_timeout_secs = read_timeout.as_secs(),
+        "SSH terminal transport profile"
+    );
+
+    // Windows: SSH keepalive to detect dead connections.
+    #[cfg(target_os = "windows")]
+    {
+        config.keepalive_interval = Some(std::time::Duration::from_secs(15));
+        config.keepalive_max = 3;
+    }
+
+    // Legacy localhost/HvSocket path: cap SSH window to avoid transport
+    // backpressure deadlocks. For TCP guest_ip path, keep default values.
+    #[cfg(target_os = "windows")]
+    {
+        if is_localhost_ssh {
+            config.window_size = 262144; // 256KB
+            config.maximum_packet_size = 32768;
+        }
+    }
+
     let config = std::sync::Arc::new(config);
     let sh = SshHandler;
     let mut session =
@@ -327,42 +365,82 @@ pub async fn connect_ssh(
         });
     }
 
-    // Spawn read loop: forwards SSH channel data to TUI events
+    // Spawn read loop: forwards SSH channel data to TUI events.
     let tx_read = tx;
     tokio::spawn(async move {
         use russh::ChannelMsg;
-        while let Some(msg) = read_half.wait().await {
+
+        let mut consecutive_timeouts: u32 = 0;
+
+        loop {
+            let msg = tokio::time::timeout(read_timeout, read_half.wait()).await;
             match msg {
-                ChannelMsg::Data { data } => {
-                    let _ = tx_read.send(AppEvent::TerminalData {
-                        panel_idx,
-                        data: data.to_vec(),
-                    });
+                Ok(Some(msg)) => {
+                    consecutive_timeouts = 0;
+                    match msg {
+                        ChannelMsg::Data { data } => {
+                            let _ = tx_read.send(AppEvent::TerminalData {
+                                panel_idx,
+                                data: data.to_vec(),
+                            });
+                        }
+                        ChannelMsg::ExtendedData { data, .. } => {
+                            let _ = tx_read.send(AppEvent::TerminalData {
+                                panel_idx,
+                                data: data.to_vec(),
+                            });
+                        }
+                        ChannelMsg::Eof | ChannelMsg::Close => {
+                            let _ = tx_read.send(AppEvent::SshDisconnected {
+                                panel_idx,
+                                error: None,
+                            });
+                            break;
+                        }
+                        ChannelMsg::ExitStatus { exit_status } => {
+                            let _ = tx_read.send(AppEvent::SshDisconnected {
+                                panel_idx,
+                                error: if exit_status != 0 {
+                                    Some(format!("Remote process exited with status {}", exit_status))
+                                } else {
+                                    None
+                                },
+                            });
+                        }
+                        _ => {}
+                    }
                 }
-                ChannelMsg::ExtendedData { data, .. } => {
-                    let _ = tx_read.send(AppEvent::TerminalData {
-                        panel_idx,
-                        data: data.to_vec(),
-                    });
-                }
-                ChannelMsg::Eof | ChannelMsg::Close => {
+                Ok(None) => {
+                    // Channel dropped / connection lost.
+                    tracing::warn!(panel_idx, "SSH channel read returned None (connection lost)");
                     let _ = tx_read.send(AppEvent::SshDisconnected {
                         panel_idx,
-                        error: None,
+                        error: Some("SSH connection lost".to_string()),
                     });
                     break;
                 }
-                ChannelMsg::ExitStatus { exit_status } => {
-                    let _ = tx_read.send(AppEvent::SshDisconnected {
+                Err(_elapsed) => {
+                    consecutive_timeouts += 1;
+                    tracing::warn!(
                         panel_idx,
-                        error: if exit_status != 0 {
-                            Some(format!("Remote process exited with status {}", exit_status))
+                        consecutive_timeouts,
+                        timeout_secs = read_timeout.as_secs(),
+                        "SSH channel read timed out"
+                    );
+                    let max_timeouts: u32 = if aggressive_stall_detection { 1 } else { 3 };
+                    if consecutive_timeouts >= max_timeouts {
+                        let msg = if aggressive_stall_detection {
+                            "SSH connection stalled (no data received). Use /reconnect to retry.".to_string()
                         } else {
-                            None
-                        },
-                    });
+                            "SSH channel timed out waiting for data.".to_string()
+                        };
+                        let _ = tx_read.send(AppEvent::SshDisconnected {
+                            panel_idx,
+                            error: Some(msg),
+                        });
+                        break;
+                    }
                 }
-                _ => {}
             }
         }
     });
@@ -840,7 +918,11 @@ pub fn extract_urls_from_screen(screen: &vt100::Screen) -> Vec<String> {
 /// This prevents random URLs printed by agents from spawning browser tabs.
 const AUTH_DOMAINS: &[&str] = &[
     // Claude Code
+    "claude.com",               // Claude Code OAuth authorize (new host)
+    "www.claude.com",           // Claude web redirect/auth host (new host)
     "claude.ai",                // Claude Code CLI (OAuth authorize)
+    "www.claude.ai",            // Claude web redirect/auth host
+    "platform.claude.com",      // Claude OAuth callback/redirect host
     "auth.anthropic.com",       // Claude Code (token refresh)
     "console.anthropic.com",    // Claude Code (console auth)
     // OpenAI Codex CLI
@@ -993,12 +1075,16 @@ pub fn url_dedup_key(url: &str) -> String {
 pub fn open_url_in_browser(url: &str) {
     #[cfg(target_os = "macos")]
     {
-        let _ = std::process::Command::new("open")
+        match std::process::Command::new("open")
             .arg(url)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
-            .spawn();
+            .spawn()
+        {
+            Ok(_) => tracing::debug!(url = %url, "Spawned browser open command"),
+            Err(e) => tracing::warn!(url = %url, error = %e, "Failed to spawn browser open command"),
+        }
     }
     #[cfg(target_os = "windows")]
     {
@@ -1006,21 +1092,29 @@ pub fn open_url_in_browser(url: &str) {
         // breaks OAuth URLs containing '&' (command separator) and '%' (env var
         // expansion).  The URL is passed as a single process argument, so all
         // special characters are preserved.
-        let _ = std::process::Command::new("rundll32")
+        match std::process::Command::new("rundll32")
             .args(["url.dll,FileProtocolHandler", url])
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
-            .spawn();
+            .spawn()
+        {
+            Ok(_) => tracing::debug!(url = %url, "Spawned browser open command"),
+            Err(e) => tracing::warn!(url = %url, error = %e, "Failed to spawn browser open command"),
+        }
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        let _ = std::process::Command::new("xdg-open")
+        match std::process::Command::new("xdg-open")
             .arg(url)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
-            .spawn();
+            .spawn()
+        {
+            Ok(_) => tracing::debug!(url = %url, "Spawned browser open command"),
+            Err(e) => tracing::warn!(url = %url, error = %e, "Failed to spawn browser open command"),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- route OAuth callback forwarding through the panel-resolved SSH host and add diagnostics for URL detection/open/forward paths
- improve Windows terminal input handling with event coalescing and adaptive Ctrl+V suppression to prevent duplicate/interrupted long pastes
- extend auth domain handling for Claude URL variants and keep cross-platform behavior gated behind Windows-specific branches

## Validation
- rebuilt `nanosb.exe` and verified compilation for the updated CLI path
- validated that OAuth browser open path is exercised with debug logging

Closes #45
Closes #62