### PR TITLE
fix(windows): harden doctor and install/uninstall flow

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -73,6 +73,57 @@ function Install-NanosandboxCLI {
     # VC++ Redistributable is installed inline (no reboot needed).
     $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
         [Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    # Check if the user is in the Hyper-V Administrators group (well-known SID
+    # S-1-5-32-578). HCS APIs require either Admin or Hyper-V Administrators
+    # membership to boot sandboxes.
+    $isHyperVAdmin = $false
+    try {
+        $principal = New-Object Security.Principal.WindowsPrincipal(
+            [Security.Principal.WindowsIdentity]::GetCurrent())
+        $hypervSid = New-Object Security.Principal.SecurityIdentifier('S-1-5-32-578')
+        $isHyperVAdmin = $principal.IsInRole($hypervSid)
+    } catch {
+        $isHyperVAdmin = $false
+    }
+
+    # Upfront guidance if neither elevated nor a Hyper-V Administrator.
+    # This is the most common cause of confusing "access denied" errors at
+    # sandbox-creation time (runtime issue #133).
+    if (-not $isAdmin -and -not $isHyperVAdmin) {
+        Write-Host ""
+        Write-Warn "You are not running this installer as Administrator."
+        Write-Warn "You are also not a member of the 'Hyper-V Administrators' group."
+        Write-Host ""
+        Write-Warn "Why this matters:"
+        Write-Warn "  - Windows features (Hyper-V, WHPX, WSL, VirtualMachinePlatform)"
+        Write-Warn "    cannot be enabled automatically."
+        Write-Warn "  - Windows Defender exclusions for nanosb.exe cannot be added."
+        Write-Warn "  - Sandbox creation will fail with access-denied errors from the"
+        Write-Warn "    Host Compute Service (vmcompute) even after install completes."
+        Write-Host ""
+        Write-Warn "Recommended:"
+        Write-Warn "  1) Close this window."
+        Write-Warn "  2) Right-click PowerShell and choose 'Run as administrator'."
+        Write-Warn "  3) Re-run the installer command."
+        Write-Host ""
+        Write-Warn "If you cannot run as Administrator, ask an admin to add you to the"
+        Write-Warn "'Hyper-V Administrators' group:"
+        Write-Warn "  Add-LocalGroupMember -Group 'Hyper-V Administrators' -Member <your-user>"
+        Write-Warn "Then log out and back in for the group to take effect."
+        Write-Host ""
+        $answer = Read-Host "  Continue without elevation (the installer will skip feature setup)? [y/N]"
+        if ($answer -notmatch '^[Yy]') {
+            Write-Info "Aborted. Re-run the installer from an elevated terminal."
+            return
+        }
+        Write-Host ""
+    } elseif (-not $isAdmin -and $isHyperVAdmin) {
+        Write-Info "Running without elevation, but the current user is in 'Hyper-V Administrators'."
+        Write-Info "Sandbox creation should still work. Some installer steps (feature enables,"
+        Write-Info "Defender exclusions) require Administrator and will be skipped."
+    }
+
     $rebootNeeded = $false
 
     # -- Hyper-V --

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -181,7 +181,8 @@ function Install-NanosandboxCLI {
     # Register a RunOnce key so the installer resumes automatically after reboot.
     if ($rebootNeeded) {
         Write-Host ""
-        Write-Warn "A restart is required to activate the features installed above."
+        Write-Warn "A single restart is required to activate all Windows virtualization features enabled above."
+        Write-Info "The installer will resume automatically after login."
         Write-Host ""
 
         # Build the resume command: re-run this installer with the same version arg

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -32,6 +32,10 @@ function Uninstall-NanosandboxCLI {
     Write-Host "  ========================================" -ForegroundColor DarkGray
     Write-Host ""
 
+    $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator
+    )
+
     # --- Remove CLI binary ---
     $nanosb = Join-Path $InstallDir "nanosb.exe"
     if (Test-Path $nanosb) {
@@ -39,6 +43,34 @@ function Uninstall-NanosandboxCLI {
         Write-Ok "Removed $nanosb"
     } else {
         Write-Info "nanosb.exe not found at $nanosb"
+    }
+
+    # --- Best-effort cleanup of installer side-effects ---
+    if ($isAdmin) {
+        try {
+            $mp = Get-MpPreference -ErrorAction SilentlyContinue
+            if ($mp) {
+                if ($mp.ExclusionPath -and ($mp.ExclusionPath -contains $InstallDir)) {
+                    Remove-MpPreference -ExclusionPath $InstallDir -ErrorAction SilentlyContinue
+                    Write-Ok "Removed Windows Defender exclusion path: $InstallDir"
+                }
+                if ($mp.ExclusionProcess -and ($mp.ExclusionProcess -contains "nanosb.exe")) {
+                    Remove-MpPreference -ExclusionProcess "nanosb.exe" -ErrorAction SilentlyContinue
+                    Write-Ok "Removed Windows Defender exclusion process: nanosb.exe"
+                }
+            }
+        } catch {
+            Write-Warn "Could not clean Windows Defender exclusions: $_"
+        }
+
+        try {
+            Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce" -Name "NanosbInstall" -ErrorAction SilentlyContinue
+            Write-Info "Removed pending installer auto-resume key (if present)."
+        } catch {
+            Write-Warn "Could not clean installer auto-resume key: $_"
+        }
+    } else {
+        Write-Info "Run as Administrator to also clean Defender exclusions and RunOnce auto-resume key."
     }
 
     # --- Remove from PATH ---

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -87,15 +87,17 @@ function Uninstall-NanosandboxCLI {
     $depsExist = (Test-Path (Join-Path $libsDir "libkrunfw.dll")) -or
                  (Test-Path (Join-Path $libsDir "busybox")) -or
                  (Test-Path (Join-Path $libsDir "vsock_proxy")) -or
+                 (Test-Path (Join-Path $libsDir "fuse_mount")) -or
                  (Test-Path (Join-Path $libsDir "plan9_mount")) -or
                  # Legacy: old install-deps placed deps at root level
                  (Test-Path (Join-Path $InstallDir "libkrunfw.dll")) -or
                  (Test-Path (Join-Path $InstallDir "busybox")) -or
                  (Test-Path (Join-Path $InstallDir "vsock_proxy")) -or
+                 (Test-Path (Join-Path $InstallDir "fuse_mount")) -or
                  (Test-Path (Join-Path $InstallDir "plan9_mount"))
 
     if ($depsExist) {
-        Write-Host "  Runtime dependencies found (libkrunfw.dll, busybox, vsock_proxy, plan9_mount)." -ForegroundColor White
+        Write-Host "  Runtime dependencies found (libkrunfw.dll, busybox, vsock_proxy, fuse_mount)." -ForegroundColor White
         $answer = Read-Host "  Also remove runtime dependencies? [y/N]"
         if ($answer -match '^[Yy]') {
             # Remove from libs/ (current layout)
@@ -103,8 +105,8 @@ function Uninstall-NanosandboxCLI {
                 Remove-Item $libsDir -Recurse -Force
                 Write-Ok "Removed $libsDir"
             }
-            # Remove legacy root-level deps
-            foreach ($file in @('libkrunfw.dll', 'busybox', 'vsock_proxy', 'plan9_mount')) {
+            # Remove legacy root-level deps (plan9_mount kept for upgrade cleanup)
+            foreach ($file in @('libkrunfw.dll', 'busybox', 'vsock_proxy', 'fuse_mount', 'plan9_mount')) {
                 $path = Join-Path $InstallDir $file
                 if (Test-Path $path) {
                     Remove-Item $path -Force
@@ -122,7 +124,7 @@ function Uninstall-NanosandboxCLI {
         $children = Get-ChildItem $InstallDir -ErrorAction SilentlyContinue
         # Check for cache/logs/data dirs (anything beyond the binary and deps)
         $dataItems = $children | Where-Object {
-            $_.Name -notin @('nanosb.exe', 'libkrunfw.dll', 'busybox', 'vsock_proxy', 'plan9_mount', 'libs')
+            $_.Name -notin @('nanosb.exe', 'libkrunfw.dll', 'busybox', 'vsock_proxy', 'fuse_mount', 'plan9_mount', 'libs')
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1292,8 +1292,8 @@ mod cli {
                     ok_message: "found",
                 },
                 PlatformCheck {
-                    name: "plan9_mount",
-                    keyword: "plan9_mount not found",
+                    name: "fuse_mount",
+                    keyword: "fuse_mount not found",
                     ok_message: "found",
                 },
                 PlatformCheck {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1272,6 +1272,11 @@ mod cli {
                     ok_message: "running (vmcompute)",
                 },
                 PlatformCheck {
+                    name: "Hyper-V Access",
+                    keyword: "Hyper-V Administrators",
+                    ok_message: "user has Hyper-V access (admin or Hyper-V Administrators)",
+                },
+                PlatformCheck {
                     name: "WSL Kernel",
                     keyword: "WSL kernel",
                     ok_message: "found",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1282,6 +1282,21 @@ mod cli {
                     ok_message: "found",
                 },
                 PlatformCheck {
+                    name: "busybox",
+                    keyword: "busybox not found",
+                    ok_message: "found",
+                },
+                PlatformCheck {
+                    name: "vsock_proxy",
+                    keyword: "vsock_proxy not found",
+                    ok_message: "found",
+                },
+                PlatformCheck {
+                    name: "plan9_mount",
+                    keyword: "plan9_mount not found",
+                    ok_message: "found",
+                },
+                PlatformCheck {
                     name: "Disk",
                     keyword: "No SSD detected",
                     ok_message: "SSD detected",


### PR DESCRIPTION
## What changed\n- add Windows doctor checks in CLI output for usybox, sock_proxy, and plan9_mount\n- clarify installer reboot UX: a single reboot enables all Windows virtualization features and auto-resume continues after login\n- extend uninstaller cleanup to remove installer side-effects when run as Administrator:\n  - Defender exclusions (ExclusionPath and ExclusionProcess)\n  - pending RunOnce resume key (NanosbInstall)\n\n## Why\n- reduce false-green doctor output when runtime helper binaries are missing\n- make reboot behavior explicit to avoid confusion about multiple restarts\n- ensure uninstall restores host state more completely\n\n## Validation\n- PowerShell parser validation passed for scripts/install.ps1 and scripts/uninstall.ps1\n- branch pushed from clean worktree based on main\n\n## Related issues\n- No matching open/closed issue found in this repo for this exact hardening slice.