### PR TITLE
feat(cli): FUSE workspace companion — plan9 cleanup, suspend sync, run-as-root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "devices",
  "dirs",
  "docker_credential",
  "env_logger",

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -55,15 +55,15 @@ function Uninstall-NanosandboxCLI {
     $depsExist = (Test-Path (Join-Path $libsDir "libkrunfw.dll")) -or
                  (Test-Path (Join-Path $libsDir "busybox")) -or
                  (Test-Path (Join-Path $libsDir "vsock_proxy")) -or
-                 (Test-Path (Join-Path $libsDir "plan9_mount")) -or
+                 (Test-Path (Join-Path $libsDir "fuse_mount")) -or
                  # Legacy: old install-deps placed deps at root level
                  (Test-Path (Join-Path $InstallDir "libkrunfw.dll")) -or
                  (Test-Path (Join-Path $InstallDir "busybox")) -or
                  (Test-Path (Join-Path $InstallDir "vsock_proxy")) -or
-                 (Test-Path (Join-Path $InstallDir "plan9_mount"))
+                 (Test-Path (Join-Path $InstallDir "fuse_mount"))
 
     if ($depsExist) {
-        Write-Host "  Runtime dependencies found (libkrunfw.dll, busybox, vsock_proxy, plan9_mount)." -ForegroundColor White
+        Write-Host "  Runtime dependencies found (libkrunfw.dll, busybox, vsock_proxy, fuse_mount)." -ForegroundColor White
         $answer = Read-Host "  Also remove runtime dependencies? [y/N]"
         if ($answer -match '^[Yy]') {
             # Remove from libs/ (current layout)
@@ -72,7 +72,7 @@ function Uninstall-NanosandboxCLI {
                 Write-Ok "Removed $libsDir"
             }
             # Remove legacy root-level deps
-            foreach ($file in @('libkrunfw.dll', 'busybox', 'vsock_proxy', 'plan9_mount')) {
+            foreach ($file in @('libkrunfw.dll', 'busybox', 'vsock_proxy', 'fuse_mount')) {
                 $path = Join-Path $InstallDir $file
                 if (Test-Path $path) {
                     Remove-Item $path -Force
@@ -90,7 +90,7 @@ function Uninstall-NanosandboxCLI {
         $children = Get-ChildItem $InstallDir -ErrorAction SilentlyContinue
         # Check for cache/logs/data dirs (anything beyond the binary and deps)
         $dataItems = $children | Where-Object {
-            $_.Name -notin @('nanosb.exe', 'libkrunfw.dll', 'busybox', 'vsock_proxy', 'plan9_mount', 'libs')
+            $_.Name -notin @('nanosb.exe', 'libkrunfw.dll', 'busybox', 'vsock_proxy', 'fuse_mount', 'libs')
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,10 @@ mod cli {
             #[arg(long, default_value = "600")]
             timeout: u32,
 
+            /// Run agent commands as root inside the sandbox VM
+            #[arg(long)]
+            run_as_root: bool,
+
             /// Buffer output instead of streaming in real-time
             /// (only useful with --format json)
             #[arg(long)]
@@ -521,6 +525,7 @@ mod cli {
                 env_file,
                 ports,
                 timeout,
+                run_as_root,
                 buffered,
                 command,
             }) => {
@@ -534,6 +539,7 @@ mod cli {
                     env_file.as_deref(),
                     &port_pairs,
                     timeout,
+                    run_as_root,
                     buffered,
                     &command,
                     cli.format,
@@ -722,6 +728,7 @@ mod cli {
         env_file: Option<&str>,
         ports: &[(u16, u16)],
         timeout: u32,
+        run_as_root: bool,
         buffered: bool,
         command: &[String],
         format: OutputFormat,
@@ -756,7 +763,8 @@ mod cli {
             .image(&image)
             .cpus(cpus)
             .memory_mb(memory)
-            .timeout_secs(timeout);
+            .timeout_secs(timeout)
+            .run_as_root(run_as_root);
 
         for (key, value) in &env_vars {
             builder = builder.env(key, value);

--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -39,6 +39,8 @@ pub enum Command {
         model: Option<String>,
         /// Runtime env keys to import from nanosb startup env pool.
         use_env: Vec<String>,
+        /// Run agent commands as root inside the sandbox VM.
+        run_as_root: bool,
     },
     /// Switch focus to a specific panel index.
     Focus {
@@ -250,7 +252,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
         Some(a) => *a,
         None => {
             return ParseResult::Err(format!(
-                "Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n\
+                "Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n\
                  Supported agents: {}\n\
                  Example: /add claude\n\
                  With tag: /add claude --tag rc11\n\
@@ -271,6 +273,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
     let mut prompt = None;
     let mut model = None;
     let mut use_env: Vec<String> = Vec::new();
+    let mut run_as_root = false;
     let mut i = 2;
 
     while i < parts.len() {
@@ -375,6 +378,10 @@ fn parse_add(parts: &[&str]) -> ParseResult {
                 auto_mode = true;
                 i += 1;
             }
+            "--run-as-root" => {
+                run_as_root = true;
+                i += 1;
+            }
             "-p" | "--prompt" => {
                 // Consume all remaining tokens as the prompt text.
                 let remaining: Vec<&str> = parts[i + 1..].to_vec();
@@ -394,7 +401,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
             other => {
                 return ParseResult::Err(format!(
                     "Unknown option: {}\n\
-                     Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...",
+                     Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...",
                     other,
                 ));
             }
@@ -431,6 +438,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
         prompt,
         model,
         use_env,
+        run_as_root,
     })
 }
 
@@ -743,6 +751,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }
@@ -762,6 +771,27 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                run_as_root: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_add_agent_with_run_as_root() {
+        assert_eq!(
+            parse_command("/add claude --run-as-root"),
+            Some(Command::AddAgent {
+                agent: "claude".to_string(),
+                image: None,
+                tag: None,
+                project: None,
+                branch: None,
+                name: None,
+                auto_mode: false,
+                prompt: None,
+                model: None,
+                use_env: vec![],
+                run_as_root: true,
             })
         );
     }
@@ -861,6 +891,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }
@@ -1047,6 +1078,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }
@@ -1066,6 +1098,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }
@@ -1104,6 +1137,7 @@ mod tests {
                 prompt: Some("list files".to_string()),
                 model: None,
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }
@@ -1124,6 +1158,7 @@ mod tests {
                 prompt: Some("analyse project".to_string()),
                 model: None,
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }
@@ -1154,6 +1189,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec!["OPENAI_API_KEY".to_string(), "GITHUB_TOKEN".to_string()],
+                run_as_root: false,
             })
         );
     }
@@ -1179,6 +1215,7 @@ mod tests {
                 prompt: Some("fix the bug".to_string()),
                 model: None,
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }
@@ -1406,6 +1443,7 @@ mod tests {
                 prompt: None,
                 model: Some("claude-sonnet-4-5-20250929".to_string()),
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }
@@ -1436,6 +1474,7 @@ mod tests {
                 prompt: Some("do stuff".to_string()),
                 model: Some("claude-opus-4-20250514".to_string()),
                 use_env: vec![],
+                run_as_root: false,
             })
         );
     }

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -1138,6 +1138,40 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
     }
 
     if should_suspend {
+        // Best-effort flush: ask each guest to sync filesystem buffers before
+        // host-side suspend/auto-commit reads the clone directories.
+        eprintln!("Syncing guest filesystems...");
+        for (panel_idx, panel) in app.panels.iter().enumerate() {
+            let Some(sb_arc) = panel.sandbox.as_ref() else {
+                continue;
+            };
+
+            let sync_result = {
+                let sb = sb_arc.lock().await;
+                match (**sb).gateway() {
+                    Ok(gw) => tokio::time::timeout(Duration::from_secs(4), gw.exec("sync", &[])).await,
+                    Err(_) => continue,
+                }
+            };
+
+            match sync_result {
+                Ok(Ok(result)) if result.exit_code == 0 => {}
+                Ok(Ok(result)) => {
+                    eprintln!(
+                        "Warning: panel {} sync exited with code {}",
+                        panel_idx + 1,
+                        result.exit_code
+                    );
+                }
+                Ok(Err(e)) => {
+                    eprintln!("Warning: panel {} sync failed: {}", panel_idx + 1, e);
+                }
+                Err(_) => {
+                    eprintln!("Warning: panel {} sync timed out", panel_idx + 1);
+                }
+            }
+        }
+
         // Suspend session: auto-commit + sync but keep clones alive.
         eprintln!("Suspending session...");
         for panel in &mut app.panels {

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -1884,7 +1884,7 @@ async fn handle_command(
                 role: MessageRole::System,
                 content: concat!(
                     "Available commands:\n",
-                    "  /add <agent> [--image <img>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n",
+                    "  /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--image <img>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n",
                     "                                Add a new agent panel\n",
                     "  /sandboxes                    Toggle sandbox sidebar\n",
                     "  /focus <n>                    Focus panel n (0-indexed)\n",

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -2160,7 +2160,7 @@ async fn handle_command(
                 role: MessageRole::System,
                 content: concat!(
                     "Available commands:\n",
-                    "  /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--image <img>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n",
+                    "  /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <img>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n",
                     "                                Add a new agent panel\n",
                     "  /sandboxes                    Toggle sandbox sidebar\n",
                     "  /focus <n>                    Focus panel n (0-indexed)\n",
@@ -2287,8 +2287,8 @@ async fn handle_command(
         Command::McpToggle => {
             app.show_mcp_sidebar = !app.show_mcp_sidebar;
         }
-        Command::AddAgent { agent, image, tag, project, branch, name, auto_mode, prompt, model, use_env } => {
-            add_agent(app, &agent, image.as_deref(), tag.as_deref(), project.as_deref(), branch.as_deref(), name.as_deref(), auto_mode, prompt.as_deref(), model.as_deref(), &use_env, tx);
+        Command::AddAgent { agent, image, tag, project, branch, name, auto_mode, prompt, model, use_env, run_as_root } => {
+            add_agent(app, &agent, image.as_deref(), tag.as_deref(), project.as_deref(), branch.as_deref(), name.as_deref(), auto_mode, prompt.as_deref(), model.as_deref(), &use_env, run_as_root, tx);
         }
         Command::Env { assignment } => {
             handle_env(app, assignment);
@@ -4303,6 +4303,7 @@ fn add_agent(
     prompt: Option<&str>,
     model: Option<&str>,
     use_env_keys: &[String],
+    run_as_root: bool,
     tx: &mpsc::UnboundedSender<AppEvent>,
 ) {
     // Build image reference. --tag overrides the default "latest" tag
@@ -4378,7 +4379,8 @@ fn add_agent(
 
     let mut builder = SandboxConfig::builder()
         .image(&image_name)
-        .memory_mb(2048);
+        .memory_mb(2048)
+        .run_as_root(run_as_root);
 
     // Set agent type on panel (not on SandboxConfig builder).
     if let Ok(agent_type) = agent.parse::<sandbox::AgentType>() {


### PR DESCRIPTION
## What changed

Companion CLI work for the Plan9 -> FUSE-over-vsock migration on Windows.

### Commits on this branch
- 9877a56 chore: remove plan9_mount references, update to fuse_mount
- 04c3fa5 Merge branch 'main' into feat/replace-plan9-with-fuse
- e268d0d feat(tui): add pre-suspend guest sync for FUSE workspace durability
- ec1edf6 feat(cli): add --run-as-root flag for FUSE workspace mode

### Highlights
- Internal references and labels updated from \plan9_mount\ to \use_mount\.
- TUI triggers a pre-suspend guest sync so FUSE workspace files are durable before a session pause.
- New \--run-as-root\ flag on \
anosb run\ and the TUI \/add\ command for cases where NTFS-backed FUSE permissions require root in the guest (some package-manager and build workflows).

### Validation and installation
This pairs with the install/uninstall hardening PRs:
- nanosandboxai/cli#65 (doctor + uninstall checks for \use_mount\)
- nanosandboxai/runtime#136 (preflight validates \use_mount\)
- nanosandboxai/install-deps#6 (installer ships \use_mount\)
- nanosandboxai/runtime#137 (Plan9 -> FUSE migration + Windows hardening)
- nanosandboxai/agents-registry#17 (gateway run-as-root + FUSE rootfs detection)

## Related issues
- Related to nanosandboxai/runtime#134