### PR TITLE
feat: provide default compute values for code agents via config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,7 @@ jobs:
           cp scripts/uninstall.sh release/uninstall.sh
           cp scripts/install.ps1 release/install.ps1
           cp scripts/uninstall.ps1 release/uninstall.ps1
+          cp config/agent_defaults.yaml release/agent_defaults.yaml
           chmod +x release/install.sh release/uninstall.sh
           # Stamp the release tag into installer example URLs so users always
           # get the correct pinned raw URL for this specific release.

--- a/config/agent_defaults.yaml
+++ b/config/agent_defaults.yaml
@@ -1,0 +1,33 @@
+# Default compute resources for each agent type.
+#
+# These values are used when the user does not explicitly set cpus or memory
+# in their sandbox.yml or CLI flags.
+#
+# To override, edit this file at ~/.nanosandbox/agent_defaults.yaml
+# or set values in your sandbox.yml:
+#
+#   defaults:
+#     cpus: 4
+#     memory: 8192
+#
+# Resolution order (last wins):
+#   1. This file (built-in defaults, installed with nanosb)
+#   2. sandbox.yml defaults: block
+#   3. sandbox.yml per-sandbox block
+#   4. CLI flags (--cpus, --memory)
+
+claude:
+  cpus: 2
+  memory_mb: 4096
+
+codex:
+  cpus: 2
+  memory_mb: 2048
+
+goose:
+  cpus: 2
+  memory_mb: 2048
+
+cursor:
+  cpus: 2
+  memory_mb: 2048

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -401,6 +401,20 @@ function Install-NanosandboxCLI {
         Write-Warn "You may need to install them manually from: https://github.com/nanosandboxai/install-deps"
     }
 
+    # --- Install default config files ---
+    $configDest = Join-Path $InstallDir "agent_defaults.yaml"
+    if (Test-Path $configDest) {
+        Write-Info "agent_defaults.yaml already exists (keeping user config)"
+    } else {
+        $configUrl = "https://github.com/$releaseRepo/releases/download/$resolvedVersion/agent_defaults.yaml"
+        try {
+            Invoke-WebRequest -Uri $configUrl -OutFile $configDest -UseBasicParsing
+            Write-Ok "Installed agent_defaults.yaml"
+        } catch {
+            Write-Warn "Could not download agent_defaults.yaml -- using built-in defaults"
+        }
+    }
+
     # --- Add to PATH ---
     $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
     if ($userPath -notlike "*$InstallDir*") {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -167,7 +167,38 @@ download_binary() {
     fi
 }
 
-# ─── Step 3: Codesign (macOS only) ───────────────────────────────────────────
+# ─── Step 3: Install default config files ────────────────────────────────────
+
+install_config() {
+    header "Installing default configuration"
+
+    local config_dir="${NANOSANDBOX_HOME}"
+    mkdir -p "$config_dir"
+
+    local dest="${config_dir}/agent_defaults.yaml"
+
+    # Do not overwrite user-customized config.
+    if [[ -f "$dest" ]]; then
+        success "agent_defaults.yaml already exists (keeping user config)"
+        return 0
+    fi
+
+    local url
+    if [[ "$NANOSB_VERSION" == "latest" ]]; then
+        url="https://github.com/${RELEASE_REPO}/releases/latest/download/agent_defaults.yaml"
+    else
+        url="https://github.com/${RELEASE_REPO}/releases/download/v${NANOSB_VERSION}/agent_defaults.yaml"
+    fi
+
+    info "Downloading agent_defaults.yaml..."
+    if curl -fsSL "$url" -o "$dest"; then
+        success "Installed at ${dest}"
+    else
+        warn "Could not download agent_defaults.yaml — using built-in defaults"
+    fi
+}
+
+# ─── Step 4: Codesign (macOS only) ───────────────────────────────────────────
 
 codesign_binary() {
     local binary_path="${INSTALL_DIR}/nanosb"
@@ -252,6 +283,7 @@ install_symlink() {
 
 install_deps
 download_binary
+install_config
 [[ "$OS" == "Darwin" ]] && { header "Codesigning nanosb"; codesign_binary; }
 install_symlink
 

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -4371,19 +4371,26 @@ fn add_agent(
     panel.model = model.map(String::from);
 
     // Build sandbox config.
-    // Agent VMs need enough memory for the agent CLI + runtime overhead.
-    // Claude/Codex (Node.js) working set is ~1.5-2GB; 1024 OOM-killed it.
+    // Compute defaults are loaded from built-in agent profiles (and optional
+    // user overrides in ~/.nanosandbox/agent_defaults.yaml).
     let project_path = project
         .map(std::path::PathBuf::from)
         .or_else(|| app.project_path.clone());
 
+    // Resolve agent-type-aware compute defaults for cpus and memory.
+    let parsed_agent_type = agent.parse::<sandbox::AgentType>().ok();
+    let compute = parsed_agent_type
+        .map(sandbox::agent_compute_for)
+        .unwrap_or(sandbox::AgentComputeDefaults { cpus: 2, memory_mb: 2048 });
+
     let mut builder = SandboxConfig::builder()
         .image(&image_name)
-        .memory_mb(2048)
+        .cpus(compute.cpus)
+        .memory_mb(compute.memory_mb)
         .run_as_root(run_as_root);
 
     // Set agent type on panel (not on SandboxConfig builder).
-    if let Ok(agent_type) = agent.parse::<sandbox::AgentType>() {
+    if let Some(agent_type) = parsed_agent_type {
         panel.agent_type = Some(agent_type);
     }
 


### PR DESCRIPTION
## Summary

- Adds per-agent-type compute defaults (CPU + memory) with user override support
- Claude gets **2 CPUs / 4 GiB RAM** (highest — Node.js working set is ~1.5-2 GB)
- Codex, Goose, Cursor get **2 CPUs / 2 GiB RAM**
- Users can override via `~/.nanosandbox/agent_defaults.yaml`
- Defaults are applied both in the TUI `/add` command and in `sandbox.yml` resolution

## How it works

**Resolution order (last wins):**
1. Built-in defaults (hardcoded per agent type)
2. `~/.nanosandbox/agent_defaults.yaml` (user overrides)
3. `sandbox.yml` `defaults:` block
4. `sandbox.yml` per-sandbox block
5. CLI flags (`--cpus`, `--memory`)

**Example `~/.nanosandbox/agent_defaults.yaml`:**
```yaml
claude:
  cpus: 2
  memory_mb: 4096
codex:
  cpus: 2
  memory_mb: 2048
goose:
  cpus: 2
  memory_mb: 2048
cursor:
  cpus: 2
  memory_mb: 2048
```

## Changes

| Repo | File | Change |
|---|---|---|
| sandbox | `config/mod.rs` | `AgentComputeDefaults` struct, built-in defaults, `agent_compute_for()`, user override loading |
| sandbox | `config/file.rs` | Apply agent defaults in `resolve_sandbox_configs()` when no explicit cpus/memory |
| sandbox | `lib.rs` | Export new public types/functions |
| cli | `tui/run.rs` | Replace hardcoded `memory_mb(2048)` with `agent_compute_for()` in `/add` |

## Related repos

- **sandbox**: `feat/issue-64-default-agent-compute-config` branch ([nanosandboxai/sandbox@2ce7524](https://github.com/nanosandboxai/sandbox/commit/2ce7524))

Closes #64