### PR TITLE
fix(tui): carry startup env into /add panels and correct Goose resume syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1699,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2365,6 +2386,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,6 +2575,7 @@ dependencies = [
  "predicates",
  "ratatui",
  "runtime",
+ "rusqlite",
  "russh",
  "sandbox",
  "serde",
@@ -3668,6 +3701,20 @@ dependencies = [
  "tracing",
  "uuid",
  "xattr",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ async-trait = "0.1"
 sha2 = "0.10"
 env_logger = "0.11"
 log = "0.4"
+rusqlite = { version = "0.33", features = ["bundled"] }
 
 # Platform-specific (TUI terminal handling)
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,18 +430,16 @@ mod cli {
                 };
 
                 // Build runtime-only env pool for this invocation.
-                // Source order: optional auto .env (no-config mode only), then --env-file, then --env.
+                // Source order: auto .env, then --env-file, then --env.
                 let mut runtime_env: Vec<(String, String)> = Vec::new();
 
-                // Auto-load .env only when no sandbox config is active.
-                if sandbox_configs.is_empty() {
-                    if let Ok(cwd) = std::env::current_dir() {
-                        let env_path = cwd.join(".env");
-                        if env_path.exists() {
-                            let auto_env_files = vec![env_path.to_string_lossy().to_string()];
-                            let auto_env = parse_env_vars(&[], &auto_env_files)?;
-                            runtime_env.extend(auto_env);
-                        }
+                // Auto-load .env from CWD when present.
+                if let Ok(cwd) = std::env::current_dir() {
+                    let env_path = cwd.join(".env");
+                    if env_path.exists() {
+                        let auto_env_files = vec![env_path.to_string_lossy().to_string()];
+                        let auto_env = parse_env_vars(&[], &auto_env_files)?;
+                        runtime_env.extend(auto_env);
                     }
                 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -475,7 +475,7 @@ pub struct App {
     /// Pending confirmation prompt: message + list of panel indices to reconnect on 'y'.
     /// Shown as a system popup; 'y' triggers reconnect, 'n'/Esc dismisses.
     pub pending_reconnect: Option<Vec<usize>>,
-    /// Startup runtime env pool (`--env`, `--env-file`, optional auto `.env` in no-config mode).
+    /// Startup runtime env pool (`.env`, `--env-file`, `--env`).
     /// This is in-memory only for the current process.
     pub runtime_env_pool: HashMap<String, String>,
     /// Windows-only key suppression window after Ctrl+V to ignore

--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -39,6 +39,8 @@ pub enum Command {
         model: Option<String>,
         /// Runtime env keys to import from nanosb startup env pool.
         use_env: Vec<String>,
+        /// Optional env file path to merge into this panel's runtime env.
+        env_file: Option<String>,
         /// Run agent commands as root inside the sandbox VM.
         run_as_root: bool,
     },
@@ -252,12 +254,13 @@ fn parse_add(parts: &[&str]) -> ParseResult {
         Some(a) => *a,
         None => {
             return ParseResult::Err(format!(
-                "Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n\
+                "Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--env-file <path>] [--use-env <KEY>]...\n\
                  Supported agents: {}\n\
                  Example: /add claude\n\
                  With tag: /add claude --tag rc11\n\
                  With model: /add claude --model claude-sonnet-4-5-20250929\n\
                  Headless: /add claude --auto-mode -p \"list files\"\n\
+                 With env file: /add claude --env-file .env.local\n\
                  With runtime env: /add claude --use-env OPENAI_API_KEY",
                 SUPPORTED_AGENTS.join(", "),
             ));
@@ -273,6 +276,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
     let mut prompt = None;
     let mut model = None;
     let mut use_env: Vec<String> = Vec::new();
+    let mut env_file = None;
     let mut run_as_root = false;
     let mut i = 2;
 
@@ -374,6 +378,21 @@ fn parse_add(parts: &[&str]) -> ParseResult {
                     }
                 }
             }
+            "--env-file" => {
+                match parts.get(i + 1) {
+                    Some(v) => {
+                        env_file = Some(v.to_string());
+                        i += 2;
+                    }
+                    None => {
+                        return ParseResult::Err(
+                            "--env-file requires a path\n\
+                             Usage: /add <agent> --env-file <path>"
+                                .to_string(),
+                        )
+                    }
+                }
+            }
             "--auto-mode" => {
                 auto_mode = true;
                 i += 1;
@@ -401,7 +420,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
             other => {
                 return ParseResult::Err(format!(
                     "Unknown option: {}\n\
-                     Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...",
+                     Usage: /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <image>] [--project <path>] [--branch <name>] [--name <name>] [--env-file <path>] [--use-env <KEY>]...",
                     other,
                 ));
             }
@@ -438,6 +457,7 @@ fn parse_add(parts: &[&str]) -> ParseResult {
         prompt,
         model,
         use_env,
+        env_file,
         run_as_root,
     })
 }
@@ -751,6 +771,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -771,6 +792,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -791,6 +813,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: true,
             })
         );
@@ -891,6 +914,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -1078,6 +1102,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -1098,6 +1123,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -1137,6 +1163,7 @@ mod tests {
                 prompt: Some("list files".to_string()),
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -1158,6 +1185,7 @@ mod tests {
                 prompt: Some("analyse project".to_string()),
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -1189,6 +1217,7 @@ mod tests {
                 prompt: None,
                 model: None,
                 use_env: vec!["OPENAI_API_KEY".to_string(), "GITHUB_TOKEN".to_string()],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -1198,6 +1227,33 @@ mod tests {
     fn test_parse_add_use_env_missing_value() {
         let result = parse_command_verbose("/add claude --use-env");
         assert!(matches!(result, ParseResult::Err(msg) if msg.contains("--use-env requires a key name")));
+    }
+
+    #[test]
+    fn test_parse_add_with_env_file() {
+        assert_eq!(
+            parse_command_verbose("/add claude --env-file .env.local"),
+            ParseResult::Ok(Command::AddAgent {
+                agent: "claude".to_string(),
+                image: None,
+                tag: None,
+                project: None,
+                branch: None,
+                name: None,
+                auto_mode: false,
+                prompt: None,
+                model: None,
+                use_env: vec![],
+                env_file: Some(".env.local".to_string()),
+                run_as_root: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_add_env_file_missing_value() {
+        let result = parse_command_verbose("/add claude --env-file");
+        assert!(matches!(result, ParseResult::Err(msg) if msg.contains("--env-file requires a path")));
     }
 
     #[test]
@@ -1215,6 +1271,7 @@ mod tests {
                 prompt: Some("fix the bug".to_string()),
                 model: None,
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -1443,6 +1500,7 @@ mod tests {
                 prompt: None,
                 model: Some("claude-sonnet-4-5-20250929".to_string()),
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );
@@ -1474,6 +1532,7 @@ mod tests {
                 prompt: Some("do stuff".to_string()),
                 model: Some("claude-opus-4-20250514".to_string()),
                 use_env: vec![],
+                env_file: None,
                 run_as_root: false,
             })
         );

--- a/src/tui/run.rs
+++ b/src/tui/run.rs
@@ -415,7 +415,9 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
 
     // Either resume a previous session or start fresh sandboxes.
     if let Some(ref session) = resume_session_data {
-        resume_session(&mut app, session, &tx);
+        if let Err(e) = resume_session(&mut app, session, &tx) {
+            eprintln!("Warning: failed to resume session: {}", e);
+        }
     } else {
         // Auto-start sandboxes from config file.
         for (key, config) in resolved_configs {
@@ -604,7 +606,6 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                         let permissions = panel.permissions;
                         let prompt = panel.headless_state.as_ref().map(|h| h.task.clone());
                         let is_resumed = panel.is_resumed;
-                        let had_interaction = panel.had_interaction;
                         let selected_agent_session_id = panel.selected_agent_session_id.clone();
                         let model = panel.model.clone();
                         let tx = tx.clone();
@@ -1189,16 +1190,20 @@ Set NANOSB_REGISTRY_PATH or install the registry at ~/.nanosandbox/agents-regist
                 .and_then(|p| std::fs::read_to_string(p).ok())
                 .unwrap_or_default();
 
-            let session = build_session_from_app(&app, project_path, &sandbox_yml_content);
-            match session.save_with_id(resumed_session_id.as_deref()) {
-                Ok(session_id) => {
-                    eprintln!(
-                        "Session saved (id: {}). Use `nanosb -r` to resume latest or `nanosb --session {}`.",
-                        session_id, session_id
-                    );
-                }
+            match build_session_from_app(&app, project_path, &sandbox_yml_content) {
+                Ok(session) => match session.save_with_id(resumed_session_id.as_deref()) {
+                    Ok(session_id) => {
+                        eprintln!(
+                            "Session saved (id: {}). Use `nanosb -r` to resume latest or `nanosb --session {}`.",
+                            session_id, session_id
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!("Warning: failed to save session: {}", e);
+                    }
+                },
                 Err(e) => {
-                    eprintln!("Warning: failed to save session: {}", e);
+                    eprintln!("Warning: failed to build session state: {}", e);
                 }
             }
         }
@@ -2164,7 +2169,7 @@ async fn handle_command(
                 role: MessageRole::System,
                 content: concat!(
                     "Available commands:\n",
-                    "  /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <img>] [--project <path>] [--branch <name>] [--name <name>] [--use-env <KEY>]...\n",
+                    "  /add <agent> [--tag <version>] [--model <model>] [--auto-mode -p <prompt>] [--run-as-root] [--image <img>] [--project <path>] [--branch <name>] [--name <name>] [--env-file <path>] [--use-env <KEY>]...\n",
                     "                                Add a new agent panel\n",
                     "  /sandboxes                    Toggle sandbox sidebar\n",
                     "  /focus <n>                    Focus panel n (0-indexed)\n",
@@ -2291,8 +2296,8 @@ async fn handle_command(
         Command::McpToggle => {
             app.show_mcp_sidebar = !app.show_mcp_sidebar;
         }
-        Command::AddAgent { agent, image, tag, project, branch, name, auto_mode, prompt, model, use_env, run_as_root } => {
-            add_agent(app, &agent, image.as_deref(), tag.as_deref(), project.as_deref(), branch.as_deref(), name.as_deref(), auto_mode, prompt.as_deref(), model.as_deref(), &use_env, run_as_root, tx);
+        Command::AddAgent { agent, image, tag, project, branch, name, auto_mode, prompt, model, use_env, env_file, run_as_root } => {
+            add_agent(app, &agent, image.as_deref(), tag.as_deref(), project.as_deref(), branch.as_deref(), name.as_deref(), auto_mode, prompt.as_deref(), model.as_deref(), &use_env, env_file.as_deref(), run_as_root, tx);
         }
         Command::Env { assignment } => {
             handle_env(app, assignment);
@@ -4296,6 +4301,24 @@ fn required_api_keys(agent: &str) -> Vec<(&'static str, bool)> {
     }
 }
 
+fn parse_runtime_env_file(path: &str) -> std::result::Result<Vec<(String, String)>, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read env file '{}': {}", path, e))?;
+
+    let mut vars = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            vars.push((key.trim().to_string(), value.trim().to_string()));
+        }
+    }
+
+    Ok(vars)
+}
+
 /// Add a new agent panel, creating and starting a sandbox in the background.
 fn add_agent(
     app: &mut App,
@@ -4309,6 +4332,7 @@ fn add_agent(
     prompt: Option<&str>,
     model: Option<&str>,
     use_env_keys: &[String],
+    env_file: Option<&str>,
     run_as_root: bool,
     tx: &mpsc::UnboundedSender<AppEvent>,
 ) {
@@ -4333,10 +4357,35 @@ fn add_agent(
         panel.headless_state = Some(super::app::HeadlessState::new(task));
     }
 
+    // Import startup runtime env pool by default (lowest precedence).
+    for (key, value) in &app.runtime_env_pool {
+        panel.env.insert(key.clone(), value.clone());
+        panel.runtime_env_keys.insert(key.clone());
+    }
+
+    // Merge per-panel --env-file values over runtime defaults.
+    if let Some(env_file_path) = env_file {
+        match parse_runtime_env_file(env_file_path) {
+            Ok(file_vars) => {
+                for (key, value) in file_vars {
+                    panel.runtime_env_keys.insert(key.clone());
+                    panel.env.insert(key, value);
+                }
+            }
+            Err(e) => {
+                app.set_system_message(ChatMessage {
+                    role: MessageRole::System,
+                    content: format!("Cannot add panel: {}", e),
+                });
+                return;
+            }
+        }
+    }
+
     // Auto-detect API keys from host environment.
     for (key, _is_required) in &required_api_keys(agent) {
         if let Ok(val) = std::env::var(key) {
-            panel.env.insert(key.to_string(), val);
+            panel.env.entry(key.to_string()).or_insert(val);
         }
     }
 
@@ -4349,7 +4398,7 @@ fn add_agent(
         }
     }
 
-    // Selectively import startup runtime env keys into this panel.
+    // Explicit runtime key picks override all inferred/default values.
     if !use_env_keys.is_empty() {
         let mut missing: Vec<String> = Vec::new();
         for key in use_env_keys {
@@ -4715,29 +4764,11 @@ fn add_agent_from_config(
         }
     });
 }
-
-
-fn is_session_token_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '-' || c == '_'
-}
-
 fn normalize_agent_name(agent_name: &str) -> &str {
     match agent_name {
         "claude-code" => "claude",
         "cursor-agent" => "cursor",
         _ => agent_name,
-    }
-}
-
-fn extract_session_token_after(label: &str, text: &str) -> Option<String> {
-    let lower = text.to_lowercase();
-    let idx = lower.find(&label.to_lowercase())?;
-    let rest = text.get(idx + label.len()..)?.trim_start();
-    let token: String = rest.chars().take_while(|c| is_session_token_char(*c)).collect();
-    if token.is_empty() {
-        None
-    } else {
-        Some(token)
     }
 }
 
@@ -4806,25 +4837,57 @@ fn collect_state_files(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     files
 }
 
+fn detect_goose_session_id_from_state(
+    clone_path: &std::path::Path,
+) -> std::result::Result<Option<String>, String> {
+    let db_path = clone_path.join(".nanosb-state/.config/goose/data/sessions/sessions.db");
+    if !db_path.exists() {
+        return Ok(None);
+    }
+
+    let conn = rusqlite::Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| format!("failed to open goose sessions DB ({}): {}", db_path.display(), e))?;
+
+    match conn.query_row(
+        "SELECT id FROM sessions ORDER BY created_at DESC LIMIT 1",
+        [],
+        |row| row.get::<_, String>(0),
+    ) {
+        Ok(id) => Ok(Some(id)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(format!(
+            "failed to query goose sessions DB ({}): {}",
+            db_path.display(),
+            e
+        )),
+    }
+}
+
 fn detect_agent_session_id_from_state(
     agent_name: &str,
     clone_path: &std::path::Path,
-) -> Option<String> {
+) -> std::result::Result<Option<String>, String> {
+    if normalize_agent_name(agent_name) == "goose" {
+        return detect_goose_session_id_from_state(clone_path);
+    }
+
     let state_root = clone_path.join(".nanosb-state");
     if !state_root.exists() {
-        return None;
+        return Ok(None);
     }
 
     let agent_dir = match normalize_agent_name(agent_name) {
         "claude" => state_root.join(".claude"),
         "codex" => state_root.join(".codex"),
         "cursor" => state_root.join(".cursor"),
-        "goose" => state_root.join(".config/goose"),
         _ => state_root,
     };
 
     if !agent_dir.exists() {
-        return None;
+        return Ok(None);
     }
 
     let files = collect_state_files(&agent_dir);
@@ -4850,11 +4913,11 @@ fn detect_agent_session_id_from_state(
             }
         };
         if by_json.is_some() {
-            return by_json;
+            return Ok(by_json);
         }
     }
 
-    None
+    Ok(None)
 }
 
 fn should_resume_panel(had_interaction: bool, selected_agent_session_id: Option<&str>) -> bool {
@@ -4870,7 +4933,7 @@ fn resume_session(
     app: &mut App,
     session: &sandbox::session::Session,
     tx: &mpsc::UnboundedSender<AppEvent>,
-) {
+) -> std::result::Result<(), String> {
     for sp in &session.panels {
         let mut config = sp.config.clone();
 
@@ -4961,11 +5024,22 @@ fn resume_session(
             }
         }
 
-        let detected_session_id = panel
+        let detected_session_id = if let Some(clone) = panel
             .project_mount
             .as_ref()
             .and_then(|pm| pm.worktree_base.as_ref())
-            .and_then(|clone| detect_agent_session_id_from_state(&agent_type, clone));
+        {
+            detect_agent_session_id_from_state(&agent_type, clone).map_err(|e| {
+                format!(
+                    "failed to detect session id for agent '{}' from '{}': {}",
+                    agent_type,
+                    clone.display(),
+                    e
+                )
+            })?
+        } else {
+            None
+        };
 
         panel.selected_agent_session_id = sp
             .selected_agent_session_id
@@ -5102,6 +5176,8 @@ fn resume_session(
             }
         });
     }
+
+    Ok(())
 }
 
 /// Handle `/env` — set or list panel environment variables.
@@ -5402,71 +5478,76 @@ fn build_session_from_app(
     app: &super::app::App,
     project_path: &std::path::Path,
     sandbox_config_content: &str,
-) -> sandbox::session::Session {
+) -> std::result::Result<sandbox::session::Session, String> {
     use sandbox::session::{Session, SessionPanel, config_hash, SESSION_VERSION};
     use chrono::Utc;
 
-    let panels: Vec<SessionPanel> = app
-        .panels
-        .iter()
-        .filter_map(|panel| {
-            let config = panel.original_config.clone()?;
+    let mut panels: Vec<SessionPanel> = Vec::new();
+    for panel in &app.panels {
+        let Some(config) = panel.original_config.clone() else {
+            continue;
+        };
 
-            let clone_path = panel
-                .project_mount
-                .as_ref()
-                .and_then(|pm| pm.worktree_base.clone());
+        let clone_path = panel
+            .project_mount
+            .as_ref()
+            .and_then(|pm| pm.worktree_base.clone());
 
-            let branches = panel
-                .project_mount
-                .as_ref()
-                .map(|pm| pm.created_branches.clone())
-                .unwrap_or_default();
+        let branches = panel
+            .project_mount
+            .as_ref()
+            .map(|pm| pm.created_branches.clone())
+            .unwrap_or_default();
 
-            let env_keys: Vec<String> = panel
-                .env
-                .keys()
-                .filter(|k| !panel.runtime_env_keys.contains(*k))
-                .cloned()
-                .collect();
+        let env_keys: Vec<String> = panel
+            .env
+            .keys()
+            .filter(|k| !panel.runtime_env_keys.contains(*k))
+            .cloned()
+            .collect();
 
-            let selected_agent_session_id = panel
-                .selected_agent_session_id
-                .clone()
-                .or_else(|| {
-                    clone_path
-                        .as_ref()
-                        .and_then(|clone| detect_agent_session_id_from_state(&panel.agent_name, clone))
-                });
+        let selected_agent_session_id = if let Some(existing) = panel.selected_agent_session_id.clone() {
+            Some(existing)
+        } else if let Some(ref clone) = clone_path {
+            detect_agent_session_id_from_state(&panel.agent_name, clone).map_err(|e| {
+                format!(
+                    "failed to detect session id for agent '{}' from '{}': {}",
+                    panel.agent_name,
+                    clone.display(),
+                    e
+                )
+            })?
+        } else {
+            None
+        };
 
-            Some(SessionPanel {
-                agent_name: panel.agent_name.clone(),
-                display_name: panel.display_name.clone(),
-                sandbox_short_id: panel.sandbox_id_short.clone(),
-                config,
-                clone_path,
-                branches,
-                auto_mode: panel.auto_mode,
-                permissions: panel.permissions,
-                agent_type: panel.agent_type,
-                model: panel.model.clone(),
-                prompt: panel.headless_state.as_ref().map(|h| h.task.clone()),
-                env_keys,
-                visible: panel.visible,
-                had_interaction: panel.had_interaction,
-                selected_agent_session_id,
-            })
-        })
-        .collect();
+        panels.push(SessionPanel {
+            agent_name: panel.agent_name.clone(),
+            display_name: panel.display_name.clone(),
+            sandbox_short_id: panel.sandbox_id_short.clone(),
+            config,
+            clone_path,
+            branches,
+            auto_mode: panel.auto_mode,
+            permissions: panel.permissions,
+            agent_type: panel.agent_type,
+            model: panel.model.clone(),
+            prompt: panel.headless_state.as_ref().map(|h| h.task.clone()),
+            env_keys,
+            visible: panel.visible,
+            had_interaction: panel.had_interaction,
+            selected_agent_session_id,
+        });
+    }
 
-    Session {
+    Ok(Session {
         version: SESSION_VERSION,
         created_at: Utc::now(),
         updated_at: Utc::now(),
         project_path: project_path.to_path_buf(),
         config_hash: config_hash(sandbox_config_content),
         panels,
-    }
+    })
 }
 
 /// Merge registry resolution (full agent or skills-only) into sandbox config for bootstrap.
@@ -6125,7 +6206,8 @@ mod tests {
         )
         .expect("failed to write session file");
 
-        let detected = detect_agent_session_id_from_state("claude", &clone_dir);
+        let detected = detect_agent_session_id_from_state("claude", &clone_dir)
+            .expect("claude session id detection should not fail");
         assert_eq!(
             detected,
             Some("8df83130-8dbe-4f28-8dff-52e44405e77d".to_string())
@@ -6139,5 +6221,60 @@ mod tests {
         assert!(!should_resume_panel(false, Some("sess-1")));
         assert!(!should_resume_panel(true, None));
         assert!(should_resume_panel(true, Some("sess-1")));
+    }
+
+    #[test]
+    fn test_detect_goose_session_id_from_sqlite_db() {
+        let clone_dir = make_temp_dir("goose-session-db");
+        let db_dir = clone_dir.join(".nanosb-state/.config/goose/data/sessions");
+        fs::create_dir_all(&db_dir).expect("failed to create goose sessions dir");
+        let db_path = db_dir.join("sessions.db");
+
+        let conn = rusqlite::Connection::open(&db_path).expect("failed to open sqlite db");
+        conn.execute_batch(
+            "
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                created_at TEXT
+            );
+            INSERT INTO sessions (id, name, created_at) VALUES
+                ('20260520_1', 'older', '2026-05-20T10:00:00Z'),
+                ('20260520_2', 'newer', '2026-05-20T11:00:00Z');
+            ",
+        )
+        .expect("failed to seed sessions db");
+
+        let detected = detect_goose_session_id_from_state(&clone_dir)
+            .expect("goose sqlite detection should not fail");
+        assert_eq!(detected, Some("20260520_2".to_string()));
+
+        let _ = fs::remove_dir_all(&clone_dir);
+    }
+
+    #[test]
+    fn test_detect_goose_session_id_no_db_returns_none() {
+        let clone_dir = make_temp_dir("goose-no-db");
+        let detected = detect_goose_session_id_from_state(&clone_dir)
+            .expect("missing db should not fail");
+        assert_eq!(detected, None);
+        let _ = fs::remove_dir_all(&clone_dir);
+    }
+
+    #[test]
+    fn test_detect_goose_session_id_schema_error_fails() {
+        let clone_dir = make_temp_dir("goose-bad-schema");
+        let db_dir = clone_dir.join(".nanosb-state/.config/goose/data/sessions");
+        fs::create_dir_all(&db_dir).expect("failed to create goose sessions dir");
+        let db_path = db_dir.join("sessions.db");
+
+        let conn = rusqlite::Connection::open(&db_path).expect("failed to open sqlite db");
+        conn.execute_batch("CREATE TABLE not_sessions (id TEXT PRIMARY KEY);")
+            .expect("failed to create incompatible schema");
+
+        let detected = detect_goose_session_id_from_state(&clone_dir);
+        assert!(detected.is_err(), "schema mismatch must fail");
+
+        let _ = fs::remove_dir_all(&clone_dir);
     }
 }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -493,6 +493,7 @@ pub(super) fn agent_env_vars(
         };
         vars.insert("GOOSE_MODE".to_string(), goose_mode.to_string());
         if let Some(m) = model {
+            vars.insert("GOOSE_MODEL".to_string(), m.to_string());
             vars.insert("GOOSE_DEFAULT_MODEL".to_string(), m.to_string());
         }
     }
@@ -597,7 +598,7 @@ pub(super) fn agent_cli_command_with_session(
             if auto_mode {
                 Some("goose run --output-format stream-json --no-session -t \"$NANOSB_PROMPT\"".to_string())
             } else if let Some(session_id) = selected_session_id {
-                Some(format!("goose session resume {}", session_id))
+                Some(format!("goose session --resume --session-id {}", session_id))
             } else if is_resumed {
                 Some("goose session -r".to_string())
             } else if !has_provider {
@@ -1400,7 +1401,7 @@ mod tests {
         let cmd = agent_cli_command_with_session(
             "goose", Permissions::Default, false, true, Some("sess-123"), None, false,
         ).unwrap();
-        assert!(cmd.contains("goose session resume sess-123"));
+        assert!(cmd.contains("goose session --resume --session-id sess-123"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Always auto-load `.env` from the current working directory for TUI runs, and add `/add --env-file <path>` for per-panel env injection.
- Import startup `runtime_env_pool` into new `/add` panels by default, with explicit precedence so `--env-file` and `--use-env` overrides still work.
- Update Goose runtime env wiring to publish both `GOOSE_MODEL` and `GOOSE_DEFAULT_MODEL`, and fix explicit session resume command generation to `goose session --resume --session-id <id>`.

## Validation
- `cargo check`
- `cargo test --lib`
- `cargo test --lib tui::terminal::tests::test_agent_cli_command_goose_resume_ignores_provider`

## Related repos
- `nanosandboxai/agents-registry`: branch `feature/goose-state-persistence` persists Goose session DB under state-backed data paths.